### PR TITLE
Implement adding original files, thumbnails and extracted text to Hydra::Works

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'activefedora-aggregation', github: 'projecthydra-labs/activefedora-aggregation'
-gem 'active-fedora', github: 'projecthydra/active_fedora', branch: 'indirectly_contains'
+gem 'active-fedora', github: 'projecthydra/active_fedora'
 gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm'
 gem 'slop', '~> 3.6' # For byebug
 

--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -9,11 +9,13 @@ module Hydra
     autoload :Collection,             'hydra/works/models/collection'
     autoload :GenericWork,            'hydra/works/models/generic_work'
     autoload :GenericFile,            'hydra/works/models/generic_file'
+    autoload :File,                   'hydra/works/models/file'
     
     #behaviors
     autoload :CollectionBehavior,     'hydra/works/models/concerns/collection_behavior'
     autoload :WorkBehavior,           'hydra/works/models/concerns/work_behavior'
     autoload :FileBehavior,           'hydra/works/models/concerns/file_behavior'
+    autoload :ContainedFiles,         'hydra/works/models/concerns/contained_files'
   
   end
 end

--- a/lib/hydra/works/models/concerns/contained_files.rb
+++ b/lib/hydra/works/models/concerns/contained_files.rb
@@ -1,0 +1,28 @@
+module Hydra::Works::ContainedFiles
+  extend ActiveSupport::Concern
+
+  # We can use PCDM vocab class when projecthydra-labs/hydra-pcdm#80 is merged
+
+  included do
+    directly_contains :files, has_member_relation: ::RDF::URI("http://pcdm.org/hasFile"), class_name: "Hydra::Works::File"
+  end
+
+  def original_file
+    self.files.reject do |file|
+      file.metadata_node.query(predicate: RDF.type, object: ::RDF::URI("http://pcdm.org/OriginalFile")).map(&:object).empty?
+    end
+  end
+
+  def thumbnail
+    self.files.reject do |file|
+      file.metadata_node.query(predicate: RDF.type, object: ::RDF::URI("http://pcdm.org/ThumbnailImage")).map(&:object).empty?
+    end
+  end
+
+  def extracted_text
+    self.files.reject do |file|
+      file.metadata_node.query(predicate: RDF.type, object: ::RDF::URI("http://pcdm.org/ExtractedText")).map(&:object).empty?
+    end
+  end  
+
+end

--- a/lib/hydra/works/models/file.rb
+++ b/lib/hydra/works/models/file.rb
@@ -1,0 +1,31 @@
+module Hydra::Works
+  class File < Hydra::PCDM::File
+
+    # Need this here until projecthydra-labs/hydra-pcdm#77 is closed
+    metadata do
+      configure type: RDFVocabularies::PCDMTerms.File
+      property :label, predicate: ::RDF::RDFS.label
+    end
+
+    # We can use PCDM vocab class when projecthydra-labs/hydra-pcdm#80 is merged
+
+    def original_file= content
+      self.content = content
+      self.metadata_node.type = ::RDF::URI("http://pcdm.org/OriginalFile")
+      self.save
+    end
+
+    def thumbnail= content
+      self.content = content
+      self.metadata_node.type = ::RDF::URI("http://pcdm.org/ThumbnailImage")
+      self.save
+    end
+
+    def extracted_text= content
+      self.content = content
+      self.metadata_node.type = ::RDF::URI("http://pcdm.org/ExtractedText")
+      self.save
+    end
+
+  end
+end

--- a/lib/hydra/works/models/generic_file.rb
+++ b/lib/hydra/works/models/generic_file.rb
@@ -1,5 +1,6 @@
 module Hydra::Works
   class GenericFile < ActiveFedora::Base
     include Hydra::Works::FileBehavior
+    include Hydra::Works::ContainedFiles
   end
 end

--- a/spec/models/hydra/works/contained_files_spec.rb
+++ b/spec/models/hydra/works/contained_files_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Hydra::Works::ContainedFiles do
+
+  let(:generic_file) { Hydra::Works::GenericFile.create }
+  let(:file) { generic_file.files.build }
+
+  before do
+    generic_file.files = [file]
+    generic_file.save
+  end
+
+  describe "#thumbnail" do
+
+    describe "retrieves content of the thumbnail" do
+      before do
+        generic_file.files.first.thumbnail = "thumbnail"
+        generic_file.reload
+      end
+      subject { generic_file.thumbnail.first.content }
+      it { is_expected.to eql "thumbnail" }
+      it "retains origin pcdm.File RDF type" do
+        expect(generic_file.thumbnail.first.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
+      end
+    end
+
+    context "when no thumbnail is present" do
+      subject { generic_file.thumbnail }
+      it { is_expected.to be_empty }
+    end
+
+  end
+
+  describe "#original_file" do
+
+    describe "retrieves content of the original_file" do
+      before do
+        generic_file.files.first.original_file = "original_file"
+        generic_file.reload
+      end
+      subject { generic_file.original_file.first.content }
+      it { is_expected.to eql "original_file" }
+      it "retains origin pcdm.File RDF type" do
+        expect(generic_file.original_file.first.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
+      end
+    end
+
+    context "when no original file is present" do
+      subject { generic_file.original_file }
+      it { is_expected.to be_empty }
+    end
+
+  end
+
+  describe "#extracted_text" do
+
+    describe "retrieves content of the extracted_text" do
+      before do
+        generic_file.files.first.extracted_text = "extracted_text"
+        generic_file.reload
+      end
+      subject { generic_file.extracted_text.first.content }
+      it { is_expected.to eql "extracted_text" }
+      it "retains origin pcdm.File RDF type" do
+        expect(generic_file.extracted_text.first.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
+      end
+    end
+
+    context "when no extracted text is present" do
+      subject { generic_file.extracted_text }
+      it { is_expected.to be_empty }
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is an initial implementation that addresses #73. It adds the `files` direct container to Works and provides a mechanism for designating one of them as a pcdm.Thumbnail.