### PR TITLE
add multiple types for collections, generic works, and generic files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'activefedora-aggregation', github: 'projecthydra-labs/activefedora-aggregation'
-gem 'active-fedora', github: 'projecthydra/active_fedora'
+gem 'active-fedora', github: 'terrellt/active_fedora', branch: 'feature/UpdateAT'
+gem 'active-triples', github: 'ActiveTriples/ActiveTriples', branch: 'master'
 gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm'
 gem 'slop', '~> 3.6' # For byebug
 

--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -6,7 +6,7 @@ module Hydra
   module Works
 
     # vocabularies
-    autoload :RDFVocabularies,        'hydra/works/vocab/works_terms'
+    autoload :WorksVocabularies,      'hydra/works/vocab/works_terms'
 
     # models
     autoload :Collection,             'hydra/works/models/collection'
@@ -22,26 +22,17 @@ module Hydra
     # model validations
     def self.collection? collection
       return false unless collection.respond_to? :type
-      # collection.type.include? RDFVocabularies::WorksTerms.Collection
-
-      # TODO check for works collection instead of pcdm collection   (see issue #71)
-      Hydra::PCDM.collection? collection
+      collection.type.include? WorksVocabularies::WorksTerms.Collection
     end
 
     def self.generic_work? generic_work
       return false unless generic_work.respond_to? :type
-      # generic_work.type.include? RDFVocabularies::WorksTerms.GenericWork
-
-      # TODO check for works generic_work instead of pcdm object  (see issue #71)
-      Hydra::PCDM.object? generic_work
+      generic_work.type.include? WorksVocabularies::WorksTerms.GenericWork
     end
 
     def self.generic_file? generic_file
       return false unless generic_file.respond_to? :type
-      # generic_file.type.include? RDFVocabularies::WorksTerms.GenericFile
-
-      # TODO check for works generic_work instead of pcdm object  (see issue #71)
-      Hydra::PCDM.object? generic_file
+      generic_file.type.include? WorksVocabularies::WorksTerms.GenericFile
     end
 
   end

--- a/lib/hydra/works/models/concerns/collection_behavior.rb
+++ b/lib/hydra/works/models/concerns/collection_behavior.rb
@@ -3,10 +3,11 @@ module Hydra::Works
     extend ActiveSupport::Concern
     include Hydra::PCDM::CollectionBehavior 
 
+
     # TODO: Extend rdf type to include RDFVocabularies::WorksTerms.Collection  (see issue #71)
-    # included do
-    #   type RDFVocabularies::WorksTerms.Collection
-    # end
+    included do
+      type [RDFVocabularies::PCDMTerms.Collection,WorksVocabularies::WorksTerms.Collection]
+    end
 
     # behavior:
     #   1) Hydra::Works::Collection can aggregate Hydra::Works::Collection

--- a/lib/hydra/works/models/concerns/generic_file_behavior.rb
+++ b/lib/hydra/works/models/concerns/generic_file_behavior.rb
@@ -3,10 +3,9 @@ module Hydra::Works
     extend ActiveSupport::Concern
     include Hydra::PCDM::ObjectBehavior
 
-    # TODO: Extend rdf type to include RDFVocabularies::HydraWorks.GenericFile   (see issue #71)
-    # included do
-    #   type RDFVocabularies::WorksTerms.GenericFile
-    # end
+    included do
+      type [RDFVocabularies::PCDMTerms.Object,WorksVocabularies::WorksTerms.GenericFile]
+    end
 
     # behavior:
     #   1) Hydra::Works::GenericFile can contain (pcdm:hasFile) Hydra::PCDM::File   (inherits from Hydra::PCDM::Object)

--- a/lib/hydra/works/models/concerns/generic_work_behavior.rb
+++ b/lib/hydra/works/models/concerns/generic_work_behavior.rb
@@ -3,10 +3,9 @@ module Hydra::Works
     extend ActiveSupport::Concern
     include Hydra::PCDM::ObjectBehavior
 
-    # TODO: Extend rdf type to include RDFVocabularies::WorksTerms.GenericWork   (see issue #71)
-    # included do
-    #   type RDFVocabularies::WorksTerms.GenericWork
-    # end
+    included do
+      type [RDFVocabularies::PCDMTerms.Object,WorksVocabularies::WorksTerms.GenericWork]
+    end
 
 
     # behavior:

--- a/lib/hydra/works/vocab/works_terms.rb
+++ b/lib/hydra/works/vocab/works_terms.rb
@@ -1,5 +1,5 @@
 require 'rdf'
-module RDFVocabularies
+module WorksVocabularies
   class WorksTerms < RDF::Vocabulary("http://hydra.org/works/models#")
 
     # Class definitions

--- a/spec/hydra/works/models/generic_work_spec.rb
+++ b/spec/hydra/works/models/generic_work_spec.rb
@@ -231,7 +231,7 @@ describe Hydra::Works::GenericWork do
     end
 
     it 'should return empty array when only generic_works are aggregated' do
-      generic_work1.generic_works = [generic_work1,generic_work2]
+      generic_work1.generic_works = [generic_work2,generic_work3]
       generic_work1.save
       expect(generic_work1.generic_files).to eq []
     end


### PR DESCRIPTION
NOTE: The Gemfile ties active_fedora and active-triples to specific branches that allows for multiple types.