### PR TITLE
BUG GenericWork and GenericFile are incompatible with ActiveFedora::Base.load_instance_from_solr

### DIFF
--- a/spec/hydra/works/models/generic_work_spec.rb
+++ b/spec/hydra/works/models/generic_work_spec.rb
@@ -264,4 +264,11 @@ describe Hydra::Works::GenericWork do
     end
   end
 
+  it "is compatible with ActiveFedora::Base.load_instance_from_solr" do
+    work = ActiveFedora::Base.load_instance_from_solr(generic_work1.id)
+    expect(work.generic_files).to_not raise_error
+    expect(work.generic_files).to eq []
+    expect(work.generic_works).to eq []
+  end
+
 end


### PR DESCRIPTION
This came up in Sufia's [CopyPermissionsJob on line 13](https://github.com/projecthydra/sufia/blob/pcdm/sufia-models/app/jobs/copy_permissions_job.rb#L13) (originally from Worthwhile) where it uses ActiveFedora::Base.load_instance_from_solr to load a GenericWork and then iterates over its `.generic_files`.

ref #107 