### PR TITLE
add performance test for Add/GetGenericFilesFromGenericWork

### DIFF
--- a/spec/hydra/works/performance_tests/repeat_gets_spec.rb
+++ b/spec/hydra/works/performance_tests/repeat_gets_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe 'repeat_gets' do
+
+  context "with large number of generic files" do
+    let(:generic_works) { {   10 => Hydra::Works::GenericWork.create,
+                              50 => Hydra::Works::GenericWork.create,
+                             100 => Hydra::Works::GenericWork.create
+                            # 1000 => Hydra::Works::GenericWork.create
+                          } }
+    before do
+      puts( "============================================" )
+      puts( " Creating and appending generic files" )
+      puts( "============================================" )
+      puts( "gfile count   time (s)   time/gfile")
+      puts( "-----------   --------   ----------")
+      format = "%8d      %8.3f   %7.3f\n"
+
+      generic_works.each_pair do |generic_file_count,generic_work|
+        st = Time.now.to_f
+        generic_file_count.times do
+          Hydra::Works::AddGenericFileToGenericWork.call( generic_work, Hydra::Works::GenericFile.create )
+        end
+        t = Time.now.to_f - st
+        printf( format,10,t,t/generic_file_count )
+      end
+    end
+
+    describe 'time separate get approaches for various counts of generic files in a work' do
+      xit 'should perform consistently across each approach' do
+        format = "%-20s   %8.5f   %10.5f\n"
+        printf("\n\n")
+
+        generic_works.each_pair do |generic_file_count,generic_work|
+          puts
+          puts( "============================================" )
+          puts( " Getting #{generic_file_count} generic files 1 time" )
+          puts( "============================================" )
+          puts( "    get approach       time (s)   time/gfile (s)")
+          puts( "--------------------   --------   --------------")
+
+          st = Time.now.to_f
+          generic_work.generic_files
+          t = Time.now.to_f - st
+          printf( format,".generic_files",t,t/generic_file_count )
+
+          st = Time.now.to_f
+          Hydra::Works::GetGenericFilesFromGenericWork.call( generic_work )
+          t = Time.now.to_f - st
+          printf( format,"get service",t,t/generic_file_count )
+
+          st = Time.now.to_f
+          expect( Hydra::Works::GetGenericFilesFromGenericWork.call( generic_work ).size ).to eq generic_file_count
+          t = Time.now.to_f - st
+          printf( format,"expect + get service",t,t/generic_file_count )
+        end
+      end
+    end
+  end
+
+  context "with large number of gets" do
+    describe 'time repeatedly getting generic files from the same generic work' do
+      let(:generic_work10)   { Hydra::Works::GenericWork.create }
+      # let(:repeat_counts)    { [10,50,100,1000]}
+      let(:repeat_counts)    { [10,50,100]}
+
+      before do
+        10.times do
+          Hydra::Works::AddGenericFileToGenericWork.call( generic_work10, Hydra::Works::GenericFile.create )
+        end
+      end
+
+      xit 'should perform consistently across each approach' do
+        format = "%-20s   %8.5f   %10.5f\n"
+        printf("\n\n")
+
+        repeat_counts.each do |repeat_count|
+          puts
+          puts( "============================================" )
+          puts( " Getting 10 generic_files #{repeat_count} times" )
+          puts( "============================================" )
+          puts( "    get approach       time (s)   time/get (s)")
+          puts( "--------------------   --------   ------------")
+
+          st = Time.now.to_f
+          repeat_count.times do
+            generic_work10.generic_files
+          end
+          t = Time.now.to_f - st
+          printf( format,".generic_files",t,t/repeat_count )
+
+          st = Time.now.to_f
+          repeat_count.times do
+            Hydra::Works::GetGenericFilesFromGenericWork.call( generic_work10 )
+          end
+          t = Time.now.to_f - st
+          printf( format,"get service",t,t/repeat_count )
+
+          st = Time.now.to_f
+          repeat_count.times do
+            expect( Hydra::Works::GetGenericFilesFromGenericWork.call( generic_work10 ).size ).to eq 10
+          end
+          t = Time.now.to_f - st
+          printf( format,"expect + get service",t,t/repeat_count )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a performance test only.  By default, the tests are skipped with xit to prevent the load tests from running during normal development commits by Travis.

Results when run on my local machine.  (NOTE: results are ballpark as other processes continued to run during tests)

```
============================================
 Creating and appending generic files
============================================
gfile count   time (s)   time/gfile
-----------   --------   ----------
      10         9.787     0.979
      10        57.438     1.149
      10       129.778     1.298



============================================
 Getting 10 generic files 1 time
============================================
    get approach       time (s)   time/gfile (s)
--------------------   --------   --------------
.generic_files          0.00432      0.00043
get service             0.00599      0.00060
expect + get service    0.00519      0.00052

============================================
 Getting 50 generic files 1 time
============================================
    get approach       time (s)   time/gfile (s)
--------------------   --------   --------------
.generic_files          0.02244      0.00045
get service             0.02052      0.00041
expect + get service    0.02208      0.00044

============================================
 Getting 100 generic files 1 time
============================================
    get approach       time (s)   time/gfile (s)
--------------------   --------   --------------
.generic_files          0.04462      0.00045
get service             0.03788      0.00038
expect + get service    0.03979      0.00040
.


============================================
 Getting 10 generic_files 10 times
============================================
    get approach       time (s)   time/get (s)
--------------------   --------   ------------
.generic_files          0.03397      0.00340
get service             0.04116      0.00412
expect + get service    0.03950      0.00395

============================================
 Getting 10 generic_files 50 times
============================================
    get approach       time (s)   time/get (s)
--------------------   --------   ------------
.generic_files          0.18498      0.00370
get service             0.19359      0.00387
expect + get service    0.21452      0.00429

============================================
 Getting 10 generic_files 100 times
============================================
    get approach       time (s)   time/get (s)
--------------------   --------   ------------
.generic_files          0.36848      0.00368
get service             0.41993      0.00420
expect + get service    0.41238      0.00412
```