### PR TITLE
refactors namespaces to match Code Shredding document

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem 'activefedora-aggregation', github: 'projecthydra-labs/activefedora-aggregation'
 gem 'active-fedora', github: 'projecthydra/active_fedora', branch: 'master'
-gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm'
+gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm', ref:'c8a4654'
 gem 'slop', '~> 3.6' # For byebug
 
 unless ENV['CI']

--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -19,9 +19,10 @@ module Hydra
     autoload :CollectionBehavior,     'hydra/works/models/concerns/collection_behavior'
     autoload :GenericWorkBehavior,    'hydra/works/models/concerns/generic_work_behavior'
     autoload :GenericFileBehavior,    'hydra/works/models/concerns/generic_file_behavior'
-    autoload :ContainedFiles,         'hydra/works/models/concerns/contained_files'
-    autoload :Derivatives,            'hydra/works/models/concerns/derivatives'
-    autoload :MimeTypes,              'hydra/works/models/concerns/mime_types'
+    autoload :AggregatesGenericFiles, 'hydra/works/models/concerns/aggregates_generic_files'
+    autoload :AggregatesGenericWorks, 'hydra/works/models/concerns/aggregates_generic_works'
+    autoload :AggregatesCollections,  'hydra/works/models/concerns/aggregates_collections'
+    autoload :GenericFile,            'hydra/works/models/generic_file'
 
     # collection services
     autoload :AddCollectionToCollection,           'hydra/works/services/collection/add_collection'

--- a/lib/hydra/works/models/concerns/aggregates_collections.rb
+++ b/lib/hydra/works/models/concerns/aggregates_collections.rb
@@ -1,0 +1,16 @@
+module Hydra::Works
+  # Allows instances of a class to aggregate (pcdm:hasMember) hydra-works collections
+  module AggregatesCollections
+
+    def collections= collections
+      raise ArgumentError, "each collection must be a hydra works collection" unless collections.all? { |c| Hydra::Works.collection? c }
+      raise ArgumentError, "a collection can't be an ancestor of itself" if collection_ancestor?(collections)
+      self.members = self.generic_works + collections
+    end
+
+    def collections
+      members.to_a.select { |m| Hydra::Works.collection? m }
+    end
+
+  end
+end

--- a/lib/hydra/works/models/concerns/aggregates_generic_files.rb
+++ b/lib/hydra/works/models/concerns/aggregates_generic_files.rb
@@ -1,0 +1,20 @@
+module Hydra::Works
+  # Allows instances of a class to aggregate (pcdm:hasMember) hydra-works generic files
+  module AggregatesGenericFiles
+
+    def generic_files= generic_files
+      raise ArgumentError, "each generic_file must be a hydra works generic file" unless generic_files.all? { |w| Hydra::Works.generic_file? w }
+      raise ArgumentError, "a generic file can't be an ancestor of itself" if object_ancestor?(generic_files)
+      if self.respond_to?(:generic_works)
+        self.members = self.generic_works + generic_files
+      else
+        self.members = generic_files
+      end
+    end
+
+    def generic_files
+      members.to_a.select { |m| Hydra::Works.generic_file? m }
+    end
+  end
+
+end

--- a/lib/hydra/works/models/concerns/aggregates_generic_works.rb
+++ b/lib/hydra/works/models/concerns/aggregates_generic_works.rb
@@ -1,0 +1,20 @@
+module Hydra::Works
+  # Allows instances of a class to aggregate (pcdm:hasMember) hydra-works generic works
+  module AggregatesGenericWorks
+
+    def generic_works= generic_works
+      raise ArgumentError, "each generic_work must be a hydra works generic work" unless generic_works.all? { |w| Hydra::Works.generic_work? w }
+      raise ArgumentError, "a generic work can't be an ancestor of itself" if self.respond_to?(:object_ancestor?) && object_ancestor?(generic_works)
+      if self.respond_to?(:generic_files)
+        self.members = self.generic_files + generic_works
+      else
+        self.members = generic_works
+      end
+    end
+
+    def generic_works
+      members.to_a.select { |m| Hydra::Works.generic_work? m }
+    end
+
+  end
+end

--- a/lib/hydra/works/models/concerns/collection_behavior.rb
+++ b/lib/hydra/works/models/concerns/collection_behavior.rb
@@ -1,44 +1,27 @@
 module Hydra::Works
+
+  # This module provides all of the Behaviors of a Hydra::Works::Collection
+  #
+  # behavior:
+  #   1) Hydra::Works::Collection can aggregate Hydra::Works::Collection
+  #   2) Hydra::Works::Collection can aggregate Hydra::Works::GenericWork
+
+  #   3) Hydra::Works::Collection can NOT aggregate Hydra::PCDM::Collection unless it is also a Hydra::Works::Collection
+  #   4) Hydra::Works::Collection can NOT aggregate Hydra::Works::GenericFile
+  #   5) Hydra::Works::Collection can NOT aggregate non-PCDM object
+  #   6) Hydra::Works::Collection can NOT contain Hydra::PCDM::File
+  #   7) Hydra::Works::Collection can NOT contain
+
+  #   8) Hydra::Works::Collection can have descriptive metadata
+  #   9) Hydra::Works::Collection can have access metadata
   module CollectionBehavior
     extend ActiveSupport::Concern
-    include Hydra::PCDM::CollectionBehavior 
+    include Hydra::PCDM::CollectionBehavior
 
-
-    # TODO: Extend rdf type to include RDFVocabularies::WorksTerms.Collection  (see issue #71)
     included do
       type [RDFVocabularies::PCDMTerms.Collection,WorksVocabularies::WorksTerms.Collection]
-    end
-
-    # behavior:
-    #   1) Hydra::Works::Collection can aggregate Hydra::Works::Collection
-    #   2) Hydra::Works::Collection can aggregate Hydra::Works::GenericWork
-
-    #   3) Hydra::Works::Collection can NOT aggregate Hydra::PCDM::Collection unless it is also a Hydra::Works::Collection
-    #   4) Hydra::Works::Collection can NOT aggregate Hydra::Works::GenericFile
-    #   5) Hydra::Works::Collection can NOT aggregate non-PCDM object
-    #   6) Hydra::Works::Collection can NOT contain Hydra::PCDM::File
-    #   7) Hydra::Works::Collection can NOT contain Hydra::Works::File
-
-    #   8) Hydra::Works::Collection can have descriptive metadata
-    #   9) Hydra::Works::Collection can have access metadata
-
-    def collections= collections
-      raise ArgumentError, "each collection must be a hydra works collection" unless collections.all? { |c| Hydra::Works.collection? c }
-      raise ArgumentError, "a collection can't be an ancestor of itself" if collection_ancestor?(collections)
-      self.members = self.generic_works + collections
-    end
-
-    def collections
-      members.to_a.select { |m| Hydra::Works.collection? m }
-    end
-
-    def generic_works= generic_works
-      raise ArgumentError, "each generic_work must be a hydra works generic work" unless generic_works.all? { |w| Hydra::Works.generic_work? w }
-      self.members = self.collections + generic_works
-    end
-
-    def generic_works
-      members.to_a.select { |m| Hydra::Works.generic_work? m }
+      include Hydra::Works::AggregatesGenericWorks
+      include Hydra::Works::AggregatesCollections
     end
 
   end

--- a/lib/hydra/works/models/concerns/generic_file/contained_files.rb
+++ b/lib/hydra/works/models/concerns/generic_file/contained_files.rb
@@ -1,4 +1,4 @@
-module Hydra::Works::ContainedFiles
+module Hydra::Works::GenericFile::ContainedFiles
   extend ActiveSupport::Concern
 
   # HydraWorks supports only one each of original_file, thumbnail, and extracted_text. However

--- a/lib/hydra/works/models/concerns/generic_file/derivatives.rb
+++ b/lib/hydra/works/models/concerns/generic_file/derivatives.rb
@@ -1,4 +1,4 @@
-module Hydra::Works
+module Hydra::Works::GenericFile
   module Derivatives
     extend ActiveSupport::Concern
     

--- a/lib/hydra/works/models/concerns/generic_file/mime_types.rb
+++ b/lib/hydra/works/models/concerns/generic_file/mime_types.rb
@@ -1,5 +1,5 @@
 # This was taken directly from Sufia's GenericFile::MimeTypes
-module Hydra::Works
+module Hydra::Works::GenericFile
   module MimeTypes
     extend ActiveSupport::Concern
 

--- a/lib/hydra/works/models/concerns/generic_file_behavior.rb
+++ b/lib/hydra/works/models/concerns/generic_file_behavior.rb
@@ -1,30 +1,24 @@
 module Hydra::Works
+  # This module provides all of the Behaviors of a Hydra::Works::GenericFile
+  #
+  # behavior:
+  #   1) Hydra::Works::GenericFile can contain (pcdm:hasFile) Hydra::PCDM::File   (inherits from Hydra::PCDM::Object)
+  #   2) Hydra::Works::GenericFile can contain (pcdm:hasRelatedFile) Hydra::PCDM::File   (inherits from Hydra::PCDM::Object)
+  #   3) Hydra::Works::GenericFile can aggregate (pcdm:hasMember) Hydra::Works::GenericFile
+  #   4) Hydra::Works::GenericFile can NOT aggregate anything other than Hydra::Works::GenericFiles
+  #   5) Hydra::Works::GenericFile can have descriptive metadata
+  #   6) Hydra::Works::GenericFile can have access metadata
   module GenericFileBehavior
     extend ActiveSupport::Concern
     include Hydra::PCDM::ObjectBehavior
 
     included do
       type [RDFVocabularies::PCDMTerms.Object,WorksVocabularies::WorksTerms.GenericFile]
-    end
 
-    # behavior:
-    #   1) Hydra::Works::GenericFile can contain (pcdm:hasFile) Hydra::PCDM::File   (inherits from Hydra::PCDM::Object)
-    #   2) Hydra::Works::GenericFile can contain (pcdm:hasRelatedFile) Hydra::PCDM::File   (inherits from Hydra::PCDM::Object)
-    #   3) Hydra::Works::GenericFile can aggregate (pcdm:hasMember) Hydra::Works::GenericFile
-
-    #   4) Hydra::Works::GenericFile can NOT aggregate anything else
-
-    #   5) Hydra::Works::GenericFile can have descriptive metadata
-    #   6) Hydra::Works::GenericFile can have access metadata
-
-    def generic_files= generic_files
-      raise ArgumentError, "each generic_file must be a hydra works generic file" unless generic_files.all? { |w| Hydra::Works.generic_file? w }
-      raise ArgumentError, "a generic file can't be an ancestor of itself" if object_ancestor?(generic_files)
-      self.members = generic_files
-    end
-
-    def generic_files
-      members.to_a.select { |m| Hydra::Works.generic_file? m }
+      include Hydra::Works::AggregatesGenericFiles
+      include Hydra::Works::GenericFile::ContainedFiles
+      include Hydra::Works::GenericFile::Derivatives
+      include Hydra::Works::GenericFile::MimeTypes
     end
 
   end

--- a/lib/hydra/works/models/concerns/generic_work_behavior.rb
+++ b/lib/hydra/works/models/concerns/generic_work_behavior.rb
@@ -1,48 +1,29 @@
 module Hydra::Works
+  # This module provides all of the Behaviors of a Hydra::Works::GenericWork
+  #
+  # behavior:
+  #   1) Hydra::Works::GenericWork can aggregate Hydra::Works::GenericWork
+  #   2) Hydra::Works::GenericWork can aggregate Hydra::Works::GenericFile
+  #   3) Hydra::Works::GenericWork can NOT aggregate Hydra::PCDM::Collection
+  #   4) Hydra::Works::GenericWork can NOT aggregate Hydra::Works::Collection
+  #   5) Hydra::Works::GenericWork can NOT aggregate Works::Object unless it is also a Hydra::Works::GenericFile
+  #   6) Hydra::Works::GenericWork can NOT contain PCDM::File
+  #   7) Hydra::Works::GenericWork can NOT aggregate non-PCDM object
+  #   8) Hydra::Works::GenericWork can NOT contain Hydra::Works::GenericFile
+  #   9) Hydra::Works::GenericWork can have descriptive metadata
+  #   10) Hydra::Works::GenericWork can have access metadata
   module GenericWorkBehavior
     extend ActiveSupport::Concern
     include Hydra::PCDM::ObjectBehavior
 
     included do
       type [RDFVocabularies::PCDMTerms.Object,WorksVocabularies::WorksTerms.GenericWork]
-    end
-
-    # behavior:
-    #   1) Hydra::Works::GenericWork can aggregate Hydra::Works::GenericWork
-    #   2) Hydra::Works::GenericWork can aggregate Hydra::Works::GenericFile
-
-    #   3) Hydra::Works::GenericWork can NOT aggregate Hydra::PCDM::Collection
-    #   4) Hydra::Works::GenericWork can NOT aggregate Hydra::Works::Collection
-    #   5) Hydra::Works::GenericWork can NOT aggregate Works::Object unless it is also a Hydra::Works::GenericFile
-    #   6) Hydra::Works::GenericWork can NOT contain PCDM::File
-    #   7) Hydra::Works::GenericWork can NOT aggregate non-PCDM object
-
-    #   8) Hydra::Works::GenericWork can NOT contain Hydra::Works::File
-
-    #   9) Hydra::Works::GenericWork can have descriptive metadata
-    #   10) Hydra::Works::GenericWork can have access metadata
-
-    def generic_works= generic_works
-      raise ArgumentError, "each generic_work must be a hydra works generic work" unless generic_works.all? { |w| Hydra::Works.generic_work? w }
-      raise ArgumentError, "a generic work can't be an ancestor of itself" if object_ancestor?(generic_works)
-      self.members = self.generic_files + generic_works
-    end
-
-    def generic_works
-      members.to_a.select { |m| Hydra::Works.generic_work? m }
-    end
-
-    def generic_files= generic_files
-      raise ArgumentError, "each generic_file must be a hydra works generic file" unless generic_files.all? { |w| Hydra::Works.generic_file? w }
-      self.members = self.generic_works + generic_files
-    end
-
-    def generic_files
-      members.to_a.select { |m| Hydra::Works.generic_file? m }
+      include Hydra::Works::AggregatesGenericFiles
+      include Hydra::Works::AggregatesGenericWorks
     end
 
     def contains= files
-      raise NoMethodError, "works can not contain files"
+      raise NoMethodError, "works can not directly contain files.  You must add a GenericFile to the work's members and add files to that GenericFile."
     end
 
   end

--- a/lib/hydra/works/models/generic_file.rb
+++ b/lib/hydra/works/models/generic_file.rb
@@ -1,8 +1,17 @@
 module Hydra::Works
-  class GenericFile < ActiveFedora::Base
-    include Hydra::Works::GenericFileBehavior
-    include Hydra::Works::ContainedFiles
-    include Hydra::Works::Derivatives
-    include Hydra::Works::MimeTypes
+  # Namespace for Modules with functionality specific to GenericFiles
+  module GenericFile
+
+    extend ActiveSupport::Concern
+
+    autoload :Derivatives,            'hydra/works/models/concerns/generic_file/derivatives'
+    autoload :MimeTypes,              'hydra/works/models/concerns/generic_file/mime_types'
+    autoload :ContainedFiles,         'hydra/works/models/concerns/generic_file/contained_files'
+
+    # Base class for creating objects that behave like Hydra::Works::GenericFiles
+    class Base < ActiveFedora::Base
+      include Hydra::Works::GenericFileBehavior
+    end
+
   end
 end

--- a/lib/hydra/works/models/generic_work.rb
+++ b/lib/hydra/works/models/generic_work.rb
@@ -1,5 +1,9 @@
 module Hydra::Works
-  class GenericWork < ActiveFedora::Base
-    include Hydra::Works::GenericWorkBehavior
+  # Namespace for Modules with functionality specific to GenericWorks
+  module GenericWork
+    # Base class for creating objects that behave like Hydra::Works::GenericWorks
+    class Base < ActiveFedora::Base
+      include Hydra::Works::GenericWorkBehavior
+    end
   end
 end

--- a/lib/hydra/works/services/collection/add_generic_work.rb
+++ b/lib/hydra/works/services/collection/add_generic_work.rb
@@ -5,7 +5,7 @@ module Hydra::Works
     # Add a generic_work to a collection.
     #
     # @param [Hydra::Works::Collection] :parent_collection to which to add generic_work
-    # @param [Hydra::Works::GenericWork] :child_generic_work being added
+    # @param [Hydra::Works::GenericWork::Base] :child_generic_work being added
     #
     # @return [Hydra::Works::Collection] the updated hydra works collection
 

--- a/lib/hydra/works/services/collection/get_generic_works.rb
+++ b/lib/hydra/works/services/collection/get_generic_works.rb
@@ -6,7 +6,7 @@ module Hydra::Works
     #
     # @param [Hydra::Works::Collection] :parent_collection in which the child generic works are members
     #
-    # @return [Array<Hydra::Works::GenericWork>] all member generic works
+    # @return [Array<Hydra::Works::GenericWork::Base>] all member generic works
 
     def self.call( parent_collection )
       raise ArgumentError, 'parent_collection must be a hydra-works collection' unless Hydra::Works.collection? parent_collection

--- a/lib/hydra/works/services/collection/remove_generic_work.rb
+++ b/lib/hydra/works/services/collection/remove_generic_work.rb
@@ -5,7 +5,7 @@ module Hydra::Works
     # Remove a generic_work from a collection.
     #
     # @param [Hydra::Works::Collection] :parent_collection from which to remove generic_work
-    # @param [Hydra::Works::GenericWork] :child_generic_work being removed
+    # @param [Hydra::Works::GenericWork::Base] :child_generic_work being removed
     # @param [Fixnum] :nth_occurrence remove nth occurrence of this generic_work in the list (default=1)
     #
     # @return [Hydra::Works::Collection] the updated hydra works collection

--- a/lib/hydra/works/services/generic_file/add_generic_file.rb
+++ b/lib/hydra/works/services/generic_file/add_generic_file.rb
@@ -4,10 +4,10 @@ module Hydra::Works
     ##
     # Add a generic_file to a generic_file.
     #
-    # @param [Hydra::Works::GenericFile] :parent_generic_file to which to add generic_file
-    # @param [Hydra::Works::GenericFile] :child_generic_file being added
+    # @param [Hydra::Works::GenericFile::Base] :parent_generic_file to which to add generic_file
+    # @param [Hydra::Works::GenericFile::Base] :child_generic_file being added
     #
-    # @return [Hydra::Works::GenericFile] the updated hydra works generic file
+    # @return [Hydra::Works::GenericFile::Base] the updated hydra works generic file
 
     def self.call( parent_generic_file, child_generic_file )
       raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file

--- a/lib/hydra/works/services/generic_file/add_related_object.rb
+++ b/lib/hydra/works/services/generic_file/add_related_object.rb
@@ -4,10 +4,10 @@ module Hydra::Works
     ##
     # Add a related object to a generic file.
     #
-    # @param [Hydra::Works::GenericFile] :parent_generic_file to which to add the related object
+    # @param [Hydra::Works::GenericFile::Base] :parent_generic_file to which to add the related object
     # @param [Hydra::PCDM::Object] :child_related_object being added
     #
-    # @return [Hydra::Works::GenericFile] the updated hydra works generic file
+    # @return [Hydra::Works::GenericFile::Base] the updated hydra works generic file
 
     def self.call( parent_generic_file, child_related_object )
       raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file

--- a/lib/hydra/works/services/generic_file/get_generic_files.rb
+++ b/lib/hydra/works/services/generic_file/get_generic_files.rb
@@ -4,9 +4,9 @@ module Hydra::Works
     ##
     # Get member generic files from a generic file in order.
     #
-    # @param [Hydra::Works::GenericFile] :parent_generic_file in which the child generic files are members
+    # @param [Hydra::Works::GenericFile::Base] :parent_generic_file in which the child generic files are members
     #
-    # @return [Array<Hydra::Works::GenericFile>] all member generic files
+    # @return [Array<Hydra::Works::GenericFile::Base>] all member generic files
 
     def self.call( parent_generic_file )
       raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file

--- a/lib/hydra/works/services/generic_file/get_related_objects.rb
+++ b/lib/hydra/works/services/generic_file/get_related_objects.rb
@@ -4,9 +4,9 @@ module Hydra::Works
     ##
     # Get related objects from a generic_file.
     #
-    # @param [Hydra::Works::GenericFile] :parent_generic_file to which the child objects are related
+    # @param [Hydra::Works::GenericFile::Base] :parent_generic_file to which the child objects are related
     #
-    # @return [Array<Hydra::Works::GenericFile>] all related objects
+    # @return [Array<Hydra::Works::GenericFile::Base>] all related objects
 
     def self.call( parent_generic_file )
       raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file

--- a/lib/hydra/works/services/generic_file/remove_generic_file.rb
+++ b/lib/hydra/works/services/generic_file/remove_generic_file.rb
@@ -4,11 +4,11 @@ module Hydra::Works
     ##
     # Remove a generic_file from a generic_file.
     #
-    # @param [Hydra::Works::GenericFile] :parent_generic_file from which to remove generic_file
-    # @param [Hydra::Works::GenericFile] :child_generic_file being removed
+    # @param [Hydra::Works::GenericFile::Base] :parent_generic_file from which to remove generic_file
+    # @param [Hydra::Works::GenericFile::Base] :child_generic_file being removed
     # @param [Fixnum] :nth_occurrence remove nth occurrence of this generic_file in the list (default=1)
     #
-    # @return [Hydra::Works::GenericFile] the updated hydra works generic file
+    # @return [Hydra::Works::GenericFile::Base] the updated hydra works generic file
 
     def self.call( parent_generic_file, child_generic_file, nth_occurrence=1 )
       raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file

--- a/lib/hydra/works/services/generic_file/remove_related_object.rb
+++ b/lib/hydra/works/services/generic_file/remove_related_object.rb
@@ -4,10 +4,10 @@ module Hydra::Works
     ##
     # Remove an object from a generic file.
     #
-    # @param [Hydra::Works::GenericFile] :parent_generic_file from which to remove the related object
+    # @param [Hydra::Works::GenericFile::Base] :parent_generic_file from which to remove the related object
     # @param [Hydra::PCDM::Object] :child_related_object being removed
     #
-    # @return [Hydra::Works::GenericFile] the updated hydra works generic file
+    # @return [Hydra::Works::GenericFile::Base] the updated hydra works generic file
 
     def self.call( parent_generic_file, child_related_object )
       raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file

--- a/lib/hydra/works/services/generic_work/add_generic_file.rb
+++ b/lib/hydra/works/services/generic_work/add_generic_file.rb
@@ -4,10 +4,10 @@ module Hydra::Works
     ##
     # Add a generic_file to a generic_work.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work to which to add generic_work
-    # @param [Hydra::Works::GenericFile] :child_generic_file being added
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work to which to add generic_work
+    # @param [Hydra::Works::GenericFile::Base] :child_generic_file being added
     #
-    # @return [Hydra::Works::GenericWork] the updated hydra works generic work
+    # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_generic_file )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/lib/hydra/works/services/generic_work/add_generic_work.rb
+++ b/lib/hydra/works/services/generic_work/add_generic_work.rb
@@ -4,10 +4,10 @@ module Hydra::Works
     ##
     # Add a generic_work to a generic_work.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work to which to add generic_work
-    # @param [Hydra::Works::GenericWork] :child_generic_work being added
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work to which to add generic_work
+    # @param [Hydra::Works::GenericWork::Base] :child_generic_work being added
     #
-    # @return [Hydra::Works::GenericWork] the updated hydra works generic work
+    # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_generic_work )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/lib/hydra/works/services/generic_work/add_related_object.rb
+++ b/lib/hydra/works/services/generic_work/add_related_object.rb
@@ -4,10 +4,10 @@ module Hydra::Works
     ##
     # Add a related object to a generic work.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work to which to add the related object
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work to which to add the related object
     # @param [Hydra::PCDM::Object] :child_related_object being added
     #
-    # @return [Hydra::Works::GenericWork] the updated hydra works generic work
+    # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_related_object )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/lib/hydra/works/services/generic_work/get_generic_files.rb
+++ b/lib/hydra/works/services/generic_work/get_generic_files.rb
@@ -4,9 +4,9 @@ module Hydra::Works
     ##
     # Get member generic files from a generic work in order.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work in which the child generic files are members
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work in which the child generic files are members
     #
-    # @return [Array<Hydra::Works::GenericFile>] all member generic files
+    # @return [Array<Hydra::Works::GenericFile::Base>] all member generic files
 
     def self.call( parent_generic_work )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/lib/hydra/works/services/generic_work/get_generic_works.rb
+++ b/lib/hydra/works/services/generic_work/get_generic_works.rb
@@ -4,9 +4,9 @@ module Hydra::Works
     ##
     # Get member generic works from a generic work in order.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work in which the child generic works are members
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work in which the child generic works are members
     #
-    # @return [Array<Hydra::Works::GenericWork>] all member generic works
+    # @return [Array<Hydra::Works::GenericWork::Base>] all member generic works
 
     def self.call( parent_generic_work )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/lib/hydra/works/services/generic_work/get_related_objects.rb
+++ b/lib/hydra/works/services/generic_work/get_related_objects.rb
@@ -4,9 +4,9 @@ module Hydra::Works
     ##
     # Get related objects from a generic_work.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work to which the child objects are related
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work to which the child objects are related
     #
-    # @return [Array<Hydra::Works::GenericWork>] all related objects
+    # @return [Array<Hydra::Works::GenericWork::Base>] all related objects
 
     def self.call( parent_generic_work )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/lib/hydra/works/services/generic_work/remove_generic_file.rb
+++ b/lib/hydra/works/services/generic_work/remove_generic_file.rb
@@ -4,11 +4,11 @@ module Hydra::Works
     ##
     # Remove a generic_file from a generic_work.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work from which to remove generic_work
-    # @param [Hydra::Works::GenericFile] :child_generic_file being removed
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work from which to remove generic_work
+    # @param [Hydra::Works::GenericFile::Base] :child_generic_file being removed
     # @param [Fixnum] :nth_occurrence remove nth occurrence of this generic_work in the list (default=1)
     #
-    # @return [Hydra::Works::GenericWork] the updated hydra works generic work
+    # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_generic_file, nth_occurrence=1 )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/lib/hydra/works/services/generic_work/remove_generic_work.rb
+++ b/lib/hydra/works/services/generic_work/remove_generic_work.rb
@@ -4,11 +4,11 @@ module Hydra::Works
     ##
     # Remove a generic_work from a generic_work.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work from which to remove generic_work
-    # @param [Hydra::Works::GenericWork] :child_generic_work being removed
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work from which to remove generic_work
+    # @param [Hydra::Works::GenericWork::Base] :child_generic_work being removed
     # @param [Fixnum] :nth_occurrence remove nth occurrence of this generic_work in the list (default=1)
     #
-    # @return [Hydra::Works::GenericWork] the updated hydra works generic work
+    # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_generic_work, nth_occurrence=1 )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/lib/hydra/works/services/generic_work/remove_related_object.rb
+++ b/lib/hydra/works/services/generic_work/remove_related_object.rb
@@ -4,10 +4,10 @@ module Hydra::Works
     ##
     # Remove an object from a generic work.
     #
-    # @param [Hydra::Works::GenericWork] :parent_generic_work from which to remove the related object
+    # @param [Hydra::Works::GenericWork::Base] :parent_generic_work from which to remove the related object
     # @param [Hydra::PCDM::Object] :child_related_object being removed
     #
-    # @return [Hydra::Works::GenericWork] the updated hydra works generic work
+    # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_related_object )
       raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work

--- a/spec/hydra/works/models/collection_spec.rb
+++ b/spec/hydra/works/models/collection_spec.rb
@@ -6,8 +6,8 @@ describe Hydra::Works::Collection do
   let(:collection2) { Hydra::Works::Collection.create }
   let(:collection3) { Hydra::Works::Collection.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
 
   describe '#collections=' do
     it 'should aggregate collections' do

--- a/spec/hydra/works/models/concerns/file/contained_files_spec.rb
+++ b/spec/hydra/works/models/concerns/file/contained_files_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Hydra::Works::ContainedFiles do
+describe Hydra::Works::GenericFile::ContainedFiles do
 
   let(:generic_file) do
-    Hydra::Works::GenericFile.create
+    Hydra::Works::GenericFile::Base.create
   end
 
   let(:file) { generic_file.files.build }

--- a/spec/hydra/works/models/concerns/generic_file_behavior_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file_behavior_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Hydra::Works::GenericFileBehavior do
+  class IncludesGenericFileBehavior < ActiveFedora::Base
+    include Hydra::Works::GenericFileBehavior
+  end
+  subject { IncludesGenericFileBehavior.new }
+
+  it "ensures that objects will be recognized as generic_files" do
+    expect(Hydra::Works.generic_file? subject).to be_truthy
+  end
+end

--- a/spec/hydra/works/models/generic_file_spec.rb
+++ b/spec/hydra/works/models/generic_file_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Hydra::Works::GenericFile do
+describe Hydra::Works::GenericFile::Base do
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
-  let(:generic_file3) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file3) { Hydra::Works::GenericFile::Base.create }
 
   describe '#generic_files=' do
     it 'should aggregate generic_files' do

--- a/spec/hydra/works/models/generic_work_spec.rb
+++ b/spec/hydra/works/models/generic_work_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe Hydra::Works::GenericWork do
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
-  let(:generic_work3) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work3) { Hydra::Works::GenericWork::Base.create }
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
   let(:pcdm_file1)       { Hydra::PCDM::File.new }
 
@@ -29,12 +29,12 @@ describe Hydra::Works::GenericWork do
 
   describe '#contains' do
     it 'should present as a missing method' do
-      expect{ generic_work1.contains = [pcdm_file1] }.to raise_error(NoMethodError,"works can not contain files")
+      expect{ generic_work1.contains = [pcdm_file1] }.to raise_error(NoMethodError,"works can not directly contain files.  You must add a GenericFile to the work's members and add files to that GenericFile.")
     end
   end
 
   describe 'Related objects' do
-    let(:generic_work1) { Hydra::Works::GenericWork.create }
+    let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
     let(:object1) { Hydra::PCDM::Object.create }
 
     before do

--- a/spec/hydra/works/services/collection/add_collection_spec.rb
+++ b/spec/hydra/works/services/collection/add_collection_spec.rb
@@ -9,8 +9,8 @@ describe Hydra::Works::AddCollectionToCollection do
       let(:collection1) { Hydra::Works::Collection.create }
       let(:collection2) { Hydra::Works::Collection.create }
       let(:collection3) { Hydra::Works::Collection.create }
-      let(:generic_work1)  { Hydra::Works::GenericWork.create }
-      let(:generic_work2)  { Hydra::Works::GenericWork.create }
+      let(:generic_work1)  { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2)  { Hydra::Works::GenericWork::Base.create }
 
       context 'with collections and generic_works' do
         before do
@@ -81,8 +81,8 @@ describe Hydra::Works::AddCollectionToCollection do
     end
 
     context 'with unacceptable child collections' do
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -122,8 +122,8 @@ describe Hydra::Works::AddCollectionToCollection do
 
     context 'with unacceptable parent collections' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/collection/add_generic_work_spec.rb
+++ b/spec/hydra/works/services/collection/add_generic_work_spec.rb
@@ -6,9 +6,9 @@ describe Hydra::Works::AddGenericWorkToCollection do
 
   describe '#call' do
     context 'with acceptable generic_works' do
-      let(:generic_work1) { Hydra::Works::GenericWork.create }
-      let(:generic_work2) { Hydra::Works::GenericWork.create }
-      let(:generic_work3) { Hydra::Works::GenericWork.create }
+      let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work3) { Hydra::Works::GenericWork::Base.create }
       let(:collection1)   { Hydra::Works::Collection.create }
       let(:collection2)   { Hydra::Works::Collection.create }
 
@@ -55,7 +55,7 @@ describe Hydra::Works::AddGenericWorkToCollection do
 
       describe 'aggregates generic_works that extend Hydra::Works' do
         before do
-          class DummyExtWork < Hydra::Works::GenericWork
+          class DummyExtWork < Hydra::Works::GenericWork::Base
           end
         end
         after { Object.send(:remove_const, :DummyExtWork) }
@@ -71,7 +71,7 @@ describe Hydra::Works::AddGenericWorkToCollection do
 
     context 'with unacceptable child generic_works' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -110,9 +110,9 @@ describe Hydra::Works::AddGenericWorkToCollection do
     end
 
     context 'with unacceptable parent collections' do
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
-      let(:generic_work2)    { Hydra::Works::GenericWork.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/collection/add_related_object_spec.rb
+++ b/spec/hydra/works/services/collection/add_related_object_spec.rb
@@ -11,9 +11,9 @@ describe Hydra::Works::AddRelatedObjectToCollection do
       let(:object2) { Hydra::PCDM::Object.create }
       let(:collection1) { Hydra::Works::Collection.create }
       let(:collection2) { Hydra::Works::Collection.create }
-      let(:generic_work1) { Hydra::Works::GenericWork.create }
-      let(:generic_work2) { Hydra::Works::GenericWork.create }
-      let(:generic_file1) { Hydra::Works::GenericFile.create }
+      let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
 
       it 'should add various types of related objects to collection' do
         Hydra::Works::AddRelatedObjectToCollection.call( subject, generic_work1 )
@@ -89,8 +89,8 @@ describe Hydra::Works::AddRelatedObjectToCollection do
 
     context 'with unacceptable parent collections' do
       let(:pcdm_object2)     { Hydra::PCDM::Object.create }
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/collection/get_collections_spec.rb
+++ b/spec/hydra/works/services/collection/get_collections_spec.rb
@@ -7,8 +7,8 @@ describe Hydra::Works::GetCollectionsFromCollection do
   let(:collection1) { Hydra::Works::Collection.create }
   let(:collection2) { Hydra::Works::Collection.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
 
   describe '#call' do
     it 'should return empty array when only generic_works are aggregated' do

--- a/spec/hydra/works/services/collection/get_generic_works_spec.rb
+++ b/spec/hydra/works/services/collection/get_generic_works_spec.rb
@@ -7,8 +7,8 @@ describe Hydra::Works::GetGenericWorksFromCollection do
   let(:collection1) { Hydra::Works::Collection.create }
   let(:collection2) { Hydra::Works::Collection.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
 
   describe '#call' do
     it 'should return empty array when only collections are aggregated' do

--- a/spec/hydra/works/services/collection/get_related_objects_spec.rb
+++ b/spec/hydra/works/services/collection/get_related_objects_spec.rb
@@ -10,9 +10,9 @@ describe Hydra::Works::GetRelatedObjectsFromCollection do
   let(:object1) { Hydra::PCDM::Object.create }
   let(:object2) { Hydra::PCDM::Object.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
 
   describe '#call' do
     context 'with collections and generic works' do

--- a/spec/hydra/works/services/collection/remove_collection_spec.rb
+++ b/spec/hydra/works/services/collection/remove_collection_spec.rb
@@ -10,8 +10,8 @@ describe Hydra::Works::RemoveCollectionFromCollection do
     let(:collection4) { Hydra::Works::Collection.create }
     let(:collection5) { Hydra::Works::Collection.create }
 
-    let(:generic_work1) { Hydra::Works::GenericWork.create }
-    let(:generic_work2) { Hydra::Works::GenericWork.create }
+    let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+    let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
 
 
   describe '#call' do
@@ -49,8 +49,8 @@ describe Hydra::Works::RemoveCollectionFromCollection do
   end
 
   context 'with unacceptable collections' do
-    let(:generic_work1)    { Hydra::Works::GenericWork.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -91,8 +91,8 @@ describe Hydra::Works::RemoveCollectionFromCollection do
 
   context 'with unacceptable parent collection' do
     let(:collection2)      { Hydra::Works::Collection.create }
-    let(:generic_work1)    { Hydra::Works::GenericWork.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/collection/remove_generic_work_spec.rb
+++ b/spec/hydra/works/services/collection/remove_generic_work_spec.rb
@@ -4,11 +4,11 @@ describe Hydra::Works::RemoveGenericWorkFromCollection do
 
   subject { Hydra::Works::Collection.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
-  let(:generic_work3) { Hydra::Works::GenericWork.create }
-  let(:generic_work4) { Hydra::Works::GenericWork.create }
-  let(:generic_work5) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work3) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work4) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work5) { Hydra::Works::GenericWork::Base.create }
 
   let(:collection1) { Hydra::Works::Collection.create }
   let(:collection2) { Hydra::Works::Collection.create }
@@ -50,7 +50,7 @@ describe Hydra::Works::RemoveGenericWorkFromCollection do
 
   context 'with unacceptable generic works' do
     let(:collection1)    { Hydra::Works::Collection.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -90,9 +90,9 @@ describe Hydra::Works::RemoveGenericWorkFromCollection do
   end
 
   context 'with unacceptable parent collection' do
-    let(:generic_work2)    { Hydra::Works::GenericWork.create }
-    let(:generic_work1)    { Hydra::Works::GenericWork.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_work2)    { Hydra::Works::GenericWork::Base.create }
+    let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/collection/remove_related_object_spec.rb
+++ b/spec/hydra/works/services/collection/remove_related_object_spec.rb
@@ -5,14 +5,14 @@ describe Hydra::Works::RemoveRelatedObjectFromCollection do
   subject { Hydra::Works::Collection.create }
 
   let(:related_object1) { Hydra::PCDM::Object.create }
-  let(:related_work2)   { Hydra::Works::GenericWork.create }
-  let(:related_file3)   { Hydra::Works::GenericFile.create }
+  let(:related_work2)   { Hydra::Works::GenericWork::Base.create }
+  let(:related_file3)   { Hydra::Works::GenericFile::Base.create }
   let(:related_object4) { Hydra::PCDM::Object.create }
-  let(:related_work5)   { Hydra::Works::GenericWork.create }
+  let(:related_work5)   { Hydra::Works::GenericWork::Base.create }
 
   let(:collection1)   { Hydra::Works::Collection.create }
   let(:collection2)   { Hydra::Works::Collection.create }
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
 
 
   describe '#call' do
@@ -86,8 +86,8 @@ describe Hydra::Works::RemoveRelatedObjectFromCollection do
 
   context 'with unacceptable parent collection' do
     let(:related_object2)  { Hydra::PCDM::Object.create }
-    let(:generic_work1)    { Hydra::Works::GenericWork.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/generic_file/add_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_generic_file_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe Hydra::Works::AddGenericFileToGenericFile do
 
-  let(:subject) { Hydra::Works::GenericFile.create }
+  let(:subject) { Hydra::Works::GenericFile::Base.create }
 
   describe '#call' do
     context 'with acceptable generic_files' do
-      let(:generic_file1)   { Hydra::Works::GenericFile.create }
-      let(:generic_file2)   { Hydra::Works::GenericFile.create }
-      let(:generic_file3)   { Hydra::Works::GenericFile.create }
-      let(:generic_file4)   { Hydra::Works::GenericFile.create }
-      let(:generic_file5)   { Hydra::Works::GenericFile.create }
+      let(:generic_file1)   { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file2)   { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file3)   { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file4)   { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file5)   { Hydra::Works::GenericFile::Base.create }
 
       it 'should aggregate generic_files in a sub-generic_file of a generic_file' do
         Hydra::Works::AddGenericFileToGenericFile.call( generic_file1, generic_file2 )
@@ -55,7 +55,7 @@ describe Hydra::Works::AddGenericFileToGenericFile do
         end
       end
 
-      describe 'aggregates generic_files that implement Hydra::Works' do
+      describe 'aggregates generic_files that implement Hydra::Works::GenericFileBehavior' do
         before do
           class DummyIncFile < ActiveFedora::Base
             include Hydra::Works::GenericFileBehavior
@@ -71,9 +71,9 @@ describe Hydra::Works::AddGenericFileToGenericFile do
         end
       end
 
-      describe 'aggregates generic_files that extend Hydra::Works' do
+      describe 'aggregates generic_files that extend Hydra::Works::GenericFile::Base' do
         before do
-          class DummyExtFile < Hydra::Works::GenericFile
+          class DummyExtFile < Hydra::Works::GenericFile::Base
           end
         end
         after { Object.send(:remove_const, :DummyExtFile) }
@@ -89,7 +89,7 @@ describe Hydra::Works::AddGenericFileToGenericFile do
 
     context 'with unacceptable child generic_files' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -129,9 +129,9 @@ describe Hydra::Works::AddGenericFileToGenericFile do
 
     context 'with unacceptable parent generic works' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
-      let(:generic_file2)    { Hydra::Works::GenericFile.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file2)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/generic_file/add_related_object_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_related_object_spec.rb
@@ -2,17 +2,17 @@ require 'spec_helper'
 
 describe Hydra::Works::AddRelatedObjectToGenericFile do
 
-  let(:subject) { Hydra::Works::GenericFile.create }
+  let(:subject) { Hydra::Works::GenericFile::Base.create }
 
   describe '#call' do
 
     context 'with acceptable related objects' do
       let(:object1) { Hydra::PCDM::Object.create }
       let(:object2) { Hydra::PCDM::Object.create }
-      let(:generic_work1) { Hydra::Works::GenericWork.create }
-      let(:generic_work2) { Hydra::Works::GenericWork.create }
-      let(:generic_file1) { Hydra::Works::GenericFile.create }
-      let(:generic_file2) { Hydra::Works::GenericFile.create }
+      let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
       it 'should add various types of related objects to generic_file' do
         Hydra::Works::AddRelatedObjectToGenericFile.call( subject, generic_work1 )
@@ -90,7 +90,7 @@ describe Hydra::Works::AddRelatedObjectToGenericFile do
 
     context 'with unacceptable parent generic work' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_object2)     { Hydra::PCDM::Object.create }

--- a/spec/hydra/works/services/generic_file/get_generic_files_spec.rb
+++ b/spec/hydra/works/services/generic_file/get_generic_files_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe Hydra::Works::GetGenericFilesFromGenericFile do
 
-  subject { Hydra::Works::GenericFile.create }
+  subject { Hydra::Works::GenericFile::Base.create }
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
   describe '#call' do
     it 'should return generic_files when generic_files are aggregated' do

--- a/spec/hydra/works/services/generic_file/get_related_objects_spec.rb
+++ b/spec/hydra/works/services/generic_file/get_related_objects_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Hydra::Works::GetRelatedObjectsFromGenericFile do
 
-  subject { Hydra::Works::GenericFile.create }
+  subject { Hydra::Works::GenericFile::Base.create }
 
   let(:object1) { Hydra::PCDM::Object.create }
   let(:object2) { Hydra::PCDM::Object.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
   describe '#call' do
     context 'with generic files' do

--- a/spec/hydra/works/services/generic_file/remove_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/remove_generic_file_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Hydra::Works::RemoveGenericFileFromGenericFile do
 
-  subject { Hydra::Works::GenericFile.create }
+  subject { Hydra::Works::GenericFile::Base.create }
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
-  let(:generic_file3) { Hydra::Works::GenericFile.create }
-  let(:generic_file4) { Hydra::Works::GenericFile.create }
-  let(:generic_file5) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file3) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file4) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file5) { Hydra::Works::GenericFile::Base.create }
 
   describe '#call' do
     context 'when multiple collections' do
@@ -41,7 +41,7 @@ describe Hydra::Works::RemoveGenericFileFromGenericFile do
 
   context 'with unacceptable generic files' do
     let(:collection1)    { Hydra::Works::Collection.create }
-    let(:generic_work1)    { Hydra::Works::GenericWork.create }
+    let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -81,9 +81,9 @@ describe Hydra::Works::RemoveGenericFileFromGenericFile do
   end
 
   context 'with unacceptable parent generic file' do
-    let(:generic_file2)    { Hydra::Works::GenericFile.create }
+    let(:generic_file2)    { Hydra::Works::GenericFile::Base.create }
     let(:collection1)      { Hydra::Works::Collection.create }
-    let(:generic_work1)    { Hydra::Works::GenericWork.create }
+    let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/generic_file/remove_related_object_spec.rb
+++ b/spec/hydra/works/services/generic_file/remove_related_object_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 describe Hydra::Works::RemoveRelatedObjectFromGenericFile do
 
-  subject { Hydra::Works::GenericFile.create }
+  subject { Hydra::Works::GenericFile::Base.create }
 
   let(:related_object1) { Hydra::PCDM::Object.create }
-  let(:related_work2)   { Hydra::Works::GenericWork.create }
-  let(:related_file3)   { Hydra::Works::GenericFile.create }
+  let(:related_work2)   { Hydra::Works::GenericWork::Base.create }
+  let(:related_file3)   { Hydra::Works::GenericFile::Base.create }
   let(:related_object4) { Hydra::PCDM::Object.create }
-  let(:related_work5)   { Hydra::Works::GenericWork.create }
+  let(:related_work5)   { Hydra::Works::GenericWork::Base.create }
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
 
   describe '#call' do
@@ -82,7 +82,7 @@ describe Hydra::Works::RemoveRelatedObjectFromGenericFile do
   context 'with unacceptable parent generic file' do
     let(:related_object2)  { Hydra::PCDM::Object.create }
     let(:collection1)      { Hydra::Works::Collection.create }
-    let(:generic_work1)    { Hydra::Works::GenericWork.create }
+    let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/generic_file/upload_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/upload_file_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Hydra::Works::UploadFileToGenericFile do
 
-  let(:generic_work)        { Hydra::Works::GenericWork.create }
-  let(:generic_file)        { Hydra::Works::GenericFile.create }
+  let(:generic_work)        { Hydra::Works::GenericWork::Base.create }
+  let(:generic_file)        { Hydra::Works::GenericFile::Base.create }
   let(:filename)            { "sample-file.pdf" }
   let(:file)                { File.join(fixture_path, filename) }
   let(:updated_filename)    { "updated-file.txt"}

--- a/spec/hydra/works/services/generic_work/add_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_work/add_generic_file_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe Hydra::Works::AddGenericFileToGenericWork do
 
-  let(:subject) { Hydra::Works::GenericWork.create }
+  let(:subject) { Hydra::Works::GenericWork::Base.create }
 
   describe '#call' do
     context 'with acceptable generic_works' do
-      let(:generic_work1) { Hydra::Works::GenericWork.create }
-      let(:generic_work2) { Hydra::Works::GenericWork.create }
-      let(:generic_file1)   { Hydra::Works::GenericFile.create }
-      let(:generic_file2)   { Hydra::Works::GenericFile.create }
-      let(:generic_file3)   { Hydra::Works::GenericFile.create }
+      let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)   { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file2)   { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file3)   { Hydra::Works::GenericFile::Base.create }
 
       context 'with generic_files and generic_works' do
         before do
@@ -36,7 +36,7 @@ describe Hydra::Works::AddGenericFileToGenericWork do
         end
       end
 
-      describe 'aggregates generic_files that implement Hydra::Works' do
+      describe 'aggregates generic_files that implement Hydra::Works::GenericFileBehavior' do
         before do
           class DummyIncFile < ActiveFedora::Base
             include Hydra::Works::GenericFileBehavior
@@ -53,9 +53,9 @@ describe Hydra::Works::AddGenericFileToGenericWork do
 
       end
 
-      describe 'aggregates generic_files that extend Hydra::Works' do
+      describe 'aggregates generic_files that extend Hydra::Works::GenericFile::Base' do
         before do
-          class DummyExtFile < Hydra::Works::GenericFile
+          class DummyExtFile < Hydra::Works::GenericFile::Base
           end
         end
         after { Object.send(:remove_const, :DummyExtFile) }
@@ -71,7 +71,7 @@ describe Hydra::Works::AddGenericFileToGenericWork do
 
     context 'with unacceptable child generic_files' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -111,9 +111,9 @@ describe Hydra::Works::AddGenericFileToGenericWork do
 
     context 'with unacceptable parent generic works' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
-      let(:generic_work2)    { Hydra::Works::GenericWork.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/generic_work/add_generic_work_spec.rb
+++ b/spec/hydra/works/services/generic_work/add_generic_work_spec.rb
@@ -2,17 +2,17 @@ require 'spec_helper'
 
 describe Hydra::Works::AddGenericWorkToGenericWork do
 
-  let(:subject) { Hydra::Works::GenericWork.create }
+  let(:subject) { Hydra::Works::GenericWork::Base.create }
 
   describe '#call' do
     context 'with acceptable generic_works' do
-      let(:generic_work1) { Hydra::Works::GenericWork.create }
-      let(:generic_work2) { Hydra::Works::GenericWork.create }
-      let(:generic_work3) { Hydra::Works::GenericWork.create }
-      let(:generic_work4) { Hydra::Works::GenericWork.create }
-      let(:generic_work5) { Hydra::Works::GenericWork.create }
-      let(:generic_file1)   { Hydra::Works::GenericFile.create }
-      let(:generic_file2)   { Hydra::Works::GenericFile.create }
+      let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work3) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work4) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work5) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)   { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file2)   { Hydra::Works::GenericFile::Base.create }
 
       context 'with generic_files and generic_works' do
         before do
@@ -38,7 +38,7 @@ describe Hydra::Works::AddGenericWorkToGenericWork do
         end
       end
 
-      describe 'aggregates generic_works that implement Hydra::Works' do
+      describe 'aggregates generic_works that implement Hydra::Works::GenericWorkBehavior' do
         before do
           class DummyIncWork < ActiveFedora::Base
             include Hydra::Works::GenericWorkBehavior
@@ -54,9 +54,9 @@ describe Hydra::Works::AddGenericWorkToGenericWork do
         end
       end
 
-      describe 'aggregates generic_works that extend Hydra::Works' do
+      describe 'aggregates generic_works that extend Hydra::Works::GenericWork::Base' do
         before do
-          class DummyExtWork < Hydra::Works::GenericWork
+          class DummyExtWork < Hydra::Works::GenericWork::Base
           end
         end
         after { Object.send(:remove_const, :DummyExtWork) }
@@ -72,7 +72,7 @@ describe Hydra::Works::AddGenericWorkToGenericWork do
 
     context 'with unacceptable child generic_works' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -112,9 +112,9 @@ describe Hydra::Works::AddGenericWorkToGenericWork do
 
     context 'with unacceptable parent generic works' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_work1)    { Hydra::Works::GenericWork.create }
-      let(:generic_work2)    { Hydra::Works::GenericWork.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2)    { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/generic_work/add_related_object_spec.rb
+++ b/spec/hydra/works/services/generic_work/add_related_object_spec.rb
@@ -2,17 +2,17 @@ require 'spec_helper'
 
 describe Hydra::Works::AddRelatedObjectToGenericWork do
 
-  let(:subject) { Hydra::Works::GenericWork.create }
+  let(:subject) { Hydra::Works::GenericWork::Base.create }
 
   describe '#call' do
 
     context 'with acceptable related objects' do
       let(:object1) { Hydra::PCDM::Object.create }
       let(:object2) { Hydra::PCDM::Object.create }
-      let(:generic_work1) { Hydra::Works::GenericWork.create }
-      let(:generic_work2) { Hydra::Works::GenericWork.create }
-      let(:generic_file1) { Hydra::Works::GenericFile.create }
-      let(:generic_file2) { Hydra::Works::GenericFile.create }
+      let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+      let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+      let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
       it 'should add various types of related objects to generic_work' do
         Hydra::Works::AddRelatedObjectToGenericWork.call( subject, generic_work1 )
@@ -88,7 +88,7 @@ describe Hydra::Works::AddRelatedObjectToGenericWork do
 
     context 'with unacceptable parent generic work' do
       let(:collection1)      { Hydra::Works::Collection.create }
-      let(:generic_file1)    { Hydra::Works::GenericFile.create }
+      let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
       let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
       let(:pcdm_object1)     { Hydra::PCDM::Object.create }
       let(:pcdm_object2)     { Hydra::PCDM::Object.create }

--- a/spec/hydra/works/services/generic_work/get_generic_files_spec.rb
+++ b/spec/hydra/works/services/generic_work/get_generic_files_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Hydra::Works::GetGenericFilesFromGenericWork do
 
-  subject { Hydra::Works::GenericWork.create }
+  subject { Hydra::Works::GenericWork::Base.create }
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
 
   describe '#call' do
     it 'should return empty array when only generic_works are aggregated' do

--- a/spec/hydra/works/services/generic_work/get_generic_works_spec.rb
+++ b/spec/hydra/works/services/generic_work/get_generic_works_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Hydra::Works::GetGenericWorksFromGenericWork do
 
-  subject { Hydra::Works::GenericWork.create }
+  subject { Hydra::Works::GenericWork::Base.create }
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
 
   describe '#call' do
     it 'should return empty array when only generic_files are aggregated' do

--- a/spec/hydra/works/services/generic_work/get_related_objects_spec.rb
+++ b/spec/hydra/works/services/generic_work/get_related_objects_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Hydra::Works::GetRelatedObjectsFromGenericWork do
 
-  subject { Hydra::Works::GenericWork.create }
+  subject { Hydra::Works::GenericWork::Base.create }
 
   let(:object1) { Hydra::PCDM::Object.create }
   let(:object2) { Hydra::PCDM::Object.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
 
   describe '#call' do
     context 'with generic files and works' do

--- a/spec/hydra/works/services/generic_work/remove_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_work/remove_generic_file_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 describe Hydra::Works::RemoveGenericFileFromGenericWork do
 
-  subject { Hydra::Works::GenericWork.create }
+  subject { Hydra::Works::GenericWork::Base.create }
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
-  let(:generic_file3) { Hydra::Works::GenericFile.create }
-  let(:generic_file4) { Hydra::Works::GenericFile.create }
-  let(:generic_file5) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file3) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file4) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file5) { Hydra::Works::GenericFile::Base.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
 
   describe '#call' do
     context 'when multiple collections' do
@@ -49,7 +49,7 @@ describe Hydra::Works::RemoveGenericFileFromGenericWork do
 
   context 'with unacceptable generic files' do
     let(:collection1)    { Hydra::Works::Collection.create }
-    let(:generic_work1)    { Hydra::Works::GenericWork.create }
+    let(:generic_work1)    { Hydra::Works::GenericWork::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -89,9 +89,9 @@ describe Hydra::Works::RemoveGenericFileFromGenericWork do
   end
 
   context 'with unacceptable parent generic work' do
-    let(:generic_work2)    { Hydra::Works::GenericWork.create }
+    let(:generic_work2)    { Hydra::Works::GenericWork::Base.create }
     let(:collection1)      { Hydra::Works::Collection.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/generic_work/remove_generic_work_spec.rb
+++ b/spec/hydra/works/services/generic_work/remove_generic_work_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 describe Hydra::Works::RemoveGenericWorkFromGenericWork do
 
-  subject { Hydra::Works::GenericWork.create }
+  subject { Hydra::Works::GenericWork::Base.create }
 
-  let(:generic_work1) { Hydra::Works::GenericWork.create }
-  let(:generic_work2) { Hydra::Works::GenericWork.create }
-  let(:generic_work3) { Hydra::Works::GenericWork.create }
-  let(:generic_work4) { Hydra::Works::GenericWork.create }
-  let(:generic_work5) { Hydra::Works::GenericWork.create }
+  let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work3) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work4) { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work5) { Hydra::Works::GenericWork::Base.create }
 
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
-  let(:generic_file2) { Hydra::Works::GenericFile.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+  let(:generic_file2) { Hydra::Works::GenericFile::Base.create }
 
 
   describe '#call' do
@@ -50,7 +50,7 @@ describe Hydra::Works::RemoveGenericWorkFromGenericWork do
 
   context 'with unacceptable generic works' do
     let(:collection1)    { Hydra::Works::Collection.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }
@@ -90,9 +90,9 @@ describe Hydra::Works::RemoveGenericWorkFromGenericWork do
   end
 
   context 'with unacceptable parent generic work' do
-    let(:generic_work2)    { Hydra::Works::GenericWork.create }
+    let(:generic_work2)    { Hydra::Works::GenericWork::Base.create }
     let(:collection1)      { Hydra::Works::Collection.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works/services/generic_work/remove_related_object_spec.rb
+++ b/spec/hydra/works/services/generic_work/remove_related_object_spec.rb
@@ -2,17 +2,17 @@ require 'spec_helper'
 
 describe Hydra::Works::RemoveRelatedObjectFromGenericWork do
 
-  subject { Hydra::Works::GenericWork.create }
+  subject { Hydra::Works::GenericWork::Base.create }
 
   let(:related_object1) { Hydra::PCDM::Object.create }
-  let(:related_work2)   { Hydra::Works::GenericWork.create }
-  let(:related_file3)   { Hydra::Works::GenericFile.create }
+  let(:related_work2)   { Hydra::Works::GenericWork::Base.create }
+  let(:related_file3)   { Hydra::Works::GenericFile::Base.create }
   let(:related_object4) { Hydra::PCDM::Object.create }
-  let(:related_work5)   { Hydra::Works::GenericWork.create }
+  let(:related_work5)   { Hydra::Works::GenericWork::Base.create }
 
-  let(:generic_work1)   { Hydra::Works::GenericWork.create }
-  let(:generic_work2)   { Hydra::Works::GenericWork.create }
-  let(:generic_file1) { Hydra::Works::GenericFile.create }
+  let(:generic_work1)   { Hydra::Works::GenericWork::Base.create }
+  let(:generic_work2)   { Hydra::Works::GenericWork::Base.create }
+  let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
 
 
   describe '#call' do
@@ -87,7 +87,7 @@ describe Hydra::Works::RemoveRelatedObjectFromGenericWork do
   context 'with unacceptable parent generic work' do
     let(:related_object2)  { Hydra::PCDM::Object.create }
     let(:collection1)    { Hydra::Works::Collection.create }
-    let(:generic_file1)    { Hydra::Works::GenericFile.create }
+    let(:generic_file1)    { Hydra::Works::GenericFile::Base.create }
     let(:pcdm_collection1) { Hydra::PCDM::Collection.create }
     let(:pcdm_object1)     { Hydra::PCDM::Object.create }
     let(:pcdm_file1)       { Hydra::PCDM::File.new }

--- a/spec/hydra/works_spec.rb
+++ b/spec/hydra/works_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Hydra::Works do
 
   let(:works_coll)   { Hydra::Works::Collection.create }
-  let(:works_gwork)  { Hydra::Works::GenericWork.create }
-  let(:works_gfile)  { Hydra::Works::GenericFile.create }
+  let(:works_gwork)  { Hydra::Works::GenericWork::Base.create }
+  let(:works_gfile)  { Hydra::Works::GenericFile::Base.create }
 
   let(:pcdm_coll)  { Hydra::PCDM::Collection.create }
   let(:pcdm_obj)   { Hydra::PCDM::Object.create }


### PR DESCRIPTION
See [Code Shredding document](https://docs.google.com/spreadsheets/d/1uyCtjcBeSr0rWu4AieVplygrhWVTwwR0v6Itq6PBeA0/edit)

* Creates a Hydra::Works::File namespace and puts File-specific modules in there 
* Moves `generic_files` accessors into an AggregatesGenericFiles module
* adds some documentation

Also refactors GenericWork and GenericFile to be namespaces rather than classes; Renames `GenericWork` and `GenericFile` classes to `GenericWork::Base` and `GenericFile::Base`
