### PR TITLE
Use hydra-pcdm 0.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 
 gem 'activefedora-aggregation', github: 'projecthydra-labs/activefedora-aggregation'
 gem 'active-fedora', github: 'projecthydra/active_fedora', branch: 'master'
-gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm', ref:'5fcf40d'
 gem 'slop', '~> 3.6' # For byebug
 
 unless ENV['CI']


### PR DESCRIPTION
Hydra::Works should use a released version of hydra-pcdm. @flyingzumwalt after this is merged, I can cut a release of hydra-works.