### PR TITLE
AddFile service relies on kargs to know whether to version 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem 'activefedora-aggregation', github: 'projecthydra-labs/activefedora-aggregation', ref: '0dfe4f4'
 gem 'active-fedora', github: 'projecthydra/active_fedora', ref: 'caadc73'
-gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm', ref: 'a06b42a'
+gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm', ref: '11f46014'
 gem 'slop', '~> 3.6' # For byebug
 
 unless ENV['CI']

--- a/lib/hydra/works/models/concerns/generic_file/contained_files.rb
+++ b/lib/hydra/works/models/concerns/generic_file/contained_files.rb
@@ -7,7 +7,7 @@ module Hydra::Works::GenericFile::ContainedFiles
 
   # TODO: se PCDM vocab class when projecthydra-labs/hydra-pcdm#80 is merged
   included do
-    directly_contains_one :original_file, through: :files, type: ::RDF::URI("http://pcdm.org/use#OriginalFile"), class_name: "Hydra::PCDM::VersionedFile"
+    directly_contains_one :original_file, through: :files, type: ::RDF::URI("http://pcdm.org/use#OriginalFile"), class_name: "Hydra::PCDM::File"
     directly_contains_one :thumbnail, through: :files, type: ::RDF::URI("http://pcdm.org/use#ThumbnailImage"), class_name: "Hydra::PCDM::File"
     directly_contains_one :extracted_text, through: :files, type: ::RDF::URI("http://pcdm.org/use#ExtractedText"), class_name: "Hydra::PCDM::File"
   end

--- a/lib/hydra/works/services/generic_file/add_file.rb
+++ b/lib/hydra/works/services/generic_file/add_file.rb
@@ -38,7 +38,7 @@ module Hydra::Works
       current_file.original_name = ::File.basename(path)
       current_file.mime_type = Hydra::PCDM::GetMimeTypeForFile.call(path)
 
-      if current_file.versionable?
+      if versioning
         if current_file.new_record?
           generic_file.save  # this persists current_file and its membership in generic_file.files container
         else

--- a/spec/hydra/works/models/concerns/generic_file/contained_files_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file/contained_files_spec.rb
@@ -66,9 +66,9 @@ describe Hydra::Works::GenericFile::ContainedFiles do
       it "can be saved without errors" do
         expect(subject.save).to be_truthy
       end
-      it "retrieves content of the original_file as a VersionedFile" do
+      it "retrieves content of the original_file as a PCDM File" do
         expect(subject.content).to eql "original_file"
-        expect(subject).to be_instance_of Hydra::PCDM::VersionedFile
+        expect(subject).to be_instance_of Hydra::PCDM::File
       end
       it "retains origin pcdm.File RDF type" do
         expect(subject.metadata_node.type).to include(::RDF::URI("http://pcdm.org/use#OriginalFile") )

--- a/spec/hydra/works/services/generic_file/add_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_file_spec.rb
@@ -25,32 +25,37 @@ describe Hydra::Works::AddFileToGenericFile do
     end
   end
 
-  context "when the file is versionable" do
-    let(:type)  { :original_file }
+  context "when :versioning => true" do
+    let(:type)        { :original_file }
+    let(:versioning)  { true }
     subject     { reloaded }
     it "updates the file and creates a version" do
-      Hydra::Works::AddFileToGenericFile.call(generic_file, path, type)
+      Hydra::Works::AddFileToGenericFile.call(generic_file, path, type, versioning: versioning)
       expect(subject.original_file.versions.all.count).to eq(1)
       expect(subject.original_file.content).to start_with("%PDF-1.3")
     end
     context "and there are already versions" do
       before do
-        Hydra::Works::AddFileToGenericFile.call(generic_file, path, type)
-        Hydra::Works::AddFileToGenericFile.call(generic_file, path2, type)
+        Hydra::Works::AddFileToGenericFile.call(generic_file, path, type, versioning: versioning)
+        Hydra::Works::AddFileToGenericFile.call(generic_file, path2, type, versioning: versioning)
       end
       it "adds to the version history" do
         expect(subject.original_file.versions.all.count).to eq(2)
         expect(subject.original_file.content).to eq("some updated content\n")
       end
     end
-    context "but :versioning => false" do
-      before do
-        Hydra::Works::AddFileToGenericFile.call(generic_file, path, type, versioning: false)
-      end
-      it "skips creating versions" do
-        expect(subject.original_file.versions.all.count).to eq(0)
-        expect(subject.original_file.content).to start_with("%PDF-1.3")
-      end
+  end
+
+  context "when :versioning => false" do
+    let(:type)        { :original_file }
+    let(:versioning)  { false }
+    before do
+      Hydra::Works::AddFileToGenericFile.call(generic_file, path, type, versioning: versioning)
+    end
+    subject     { reloaded }
+    it "skips creating versions" do
+      expect(subject.original_file.versions.all.count).to eq(0)
+      expect(subject.original_file.content).to start_with("%PDF-1.3")
     end
   end
 


### PR DESCRIPTION
the service relies on the :versioning karg instead of calling .versionable? on the File object.  This removes  the need for a VersionedFile class.