### PR TITLE
AddFileToGenericFile validates the generic_file before attempting to save

### DIFF
--- a/lib/hydra/works/services/generic_file/add_file.rb
+++ b/lib/hydra/works/services/generic_file/add_file.rb
@@ -40,6 +40,10 @@ module Hydra::Works
       current_file.original_name = original_name ? original_name : ::File.basename(path)
       current_file.mime_type = mime_type ? mime_type : Hydra::PCDM::GetMimeTypeForFile.call(path)
 
+      # Allow generic_file to run its validations (ie. virus check)
+      # Skip saving anything and/or creating versions if it's not valid.
+      return false unless generic_file.valid?
+
       if versioning
         if current_file.new_record?
           generic_file.save  # this persists current_file and its membership in generic_file.files container

--- a/spec/hydra/works/services/generic_file/add_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_file_spec.rb
@@ -18,6 +18,15 @@ describe Hydra::Works::AddFileToGenericFile do
     end
   end
 
+  context "when generic_file is not valid" do
+    before do
+      allow(generic_file).to receive(:valid?).and_return(false)
+    end
+    it "returns false" do
+      expect( described_class.call(generic_file, path, type) ).to be false
+    end
+  end
+
   context "when you provide mime_type and original_name" do
     before { described_class.call(generic_file, path, type, mime_type: "image/png", original_name:'chosen_filename.txt') }
     subject { generic_file.filter_files_by_type(type).first }


### PR DESCRIPTION
I'm open to changing how the service responds to this situation, but it needs to do something.  Without the change, it ignores validation completely, meaning that it sometimes attempts to create file versions on unsaved objects and sometimes adds files to fedora even though the parent is not valid (meaning that, for example, a file with a virus would be saved to fedora even if the parent detected the virus)