### PR TITLE
Update AddFileToGenericFile use IO in lieu of path.

### DIFF
--- a/lib/hydra/works/services/generic_file/persist_derivative.rb
+++ b/lib/hydra/works/services/generic_file/persist_derivative.rb
@@ -9,17 +9,16 @@ module Hydra::Works
     # The purpose of this Service is for use as an alternative to the default Hydra::Derivatives::PersistOutputFileService.  It's necessary because the default behavior in Hydra::Derivatives assumes that you're using LDP Basic Containment. Hydra::Works::GenericFiles use IndirectContainment.  This Service handles that case.
     # 
     # @param [Hydra::Works::GenericFile::Base] object the file will be added to
-    # @param [File] file the dervivative filestream
-    # @param [String] destination_name path to the file
+    # @param [#read] file the dervivative filestream optionally responds to :mime_type
     # @option opts [RDF::URI or String] type URI for the RDF.type that identifies the file's role within the generic_file
     # @option opts [Boolean] update_existing when set to false, always adds a new file.  When set to true, performs a create_or_update
     # @option opts [Boolean] versioning whether to create new version entries
 
-    def self.call(object, file, destination_name, opts={})
+    def self.call(object, file, opts={})
       type = opts.fetch(:type, ::RDF::URI("http://pcdm.org/use#ServiceFile"))
       update_existing = opts.fetch(:update_existing, true)
       versioning = opts.fetch(:versioning, true)
-      Hydra::Works::AddFileToGenericFile.call(object, destination_name, type, update_existing: update_existing, versioning: versioning)
+      Hydra::Works::AddFileToGenericFile.call(object, file, type, update_existing: update_existing, versioning: versioning)
     end
 
   end

--- a/lib/hydra/works/services/generic_file/upload_file.rb
+++ b/lib/hydra/works/services/generic_file/upload_file.rb
@@ -3,17 +3,13 @@ module Hydra::Works
 
     # Sets a file as the primary file (original_file) of the generic_file
     # @param [Hydra::PCDM::GenericFile::Base] generic_file the file will be added to
-    # @param [String] path to the file
+    # @param [IO,File,Rack::Multipart::UploadedFile, #read] object that will be the contents. If file responds to :mime_type or :original_name, those will be called to provide technical metadata.
     # @param [Array] additional_services (ie Generating Thumbnails) to call with generic_file after adding the file as its original_file
     # @param [Boolean] update_existing whether to update an existing file if there is one. When set to true, performs a create_or_update. When set to false, always creates a new file within generic_file.files.
     # @param [Boolean] versioning whether to create new version entries (only applicable if +type+ corresponds to a versionable file)
 
-  def self.call(generic_file, path, additional_services: [], update_existing: true, versioning: true, mime_type: nil, original_name: nil)
-      raise ArgumentError, "supplied object must be a generic file" unless Hydra::Works.generic_file?(generic_file)
-      raise ArgumentError, "supplied path must be a string" unless path.is_a?(String)
-      raise ArgumentError, "supplied path to file does not exist" unless ::File.exists?(path)
-
-      Hydra::Works::AddFileToGenericFile.call(generic_file, path, :original_file, update_existing: update_existing, versioning: versioning, mime_type: mime_type, original_name: original_name )
+  def self.call(generic_file, file, additional_services: [], update_existing: true, versioning: true)
+      Hydra::Works::AddFileToGenericFile.call(generic_file, file, :original_file, update_existing: update_existing, versioning: versioning)
 
       # Call any additional services
       additional_services.each do |service|

--- a/spec/hydra/works/models/concerns/generic_file/versioned_content_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file/versioned_content_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Hydra::Works::GenericFile::VersionedContent do
   let(:generic_file)  { Hydra::Works::GenericFile::Base.new }
   before do
-    Hydra::Works::UploadFileToGenericFile.call(generic_file, File.join(fixture_path, "sample-file.pdf"))
-    Hydra::Works::UploadFileToGenericFile.call(generic_file, File.join(fixture_path, "updated-file.txt"))
+    Hydra::Works::UploadFileToGenericFile.call(generic_file, File.open(File.join(fixture_path, "sample-file.pdf")))
+    Hydra::Works::UploadFileToGenericFile.call(generic_file, File.open(File.join(fixture_path, "updated-file.txt")))
   end
 
   describe "content_versions" do

--- a/spec/hydra/works/services/generic_file/add_file_to_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_file_to_generic_file_spec.rb
@@ -4,15 +4,18 @@ describe Hydra::Works::AddFileToGenericFile do
 
   let(:generic_file)        { Hydra::Works::GenericFile::Base.new }
   let(:filename)            { "sample-file.pdf" }
-  let(:path)                { File.join(fixture_path, filename) }
-  let(:path2)               { File.join(fixture_path, "updated-file.txt") }
+  let(:filename2)           { "updated-file.txt" }
+  let(:original_name)       { "original-name.pdf" }
+  let(:file)                { File.open(File.join(fixture_path, filename)) }
+  let(:file2)               { File.open(File.join(fixture_path, filename2)) }
   let(:type)                { ::RDF::URI("http://pcdm.org/use#ExtractedText") }
   let(:update_existing)     { true }
+  let(:mime_type)           { "application/pdf" }
 
   context "when generic_file is not persisted" do
     let(:generic_file)        { Hydra::Works::GenericFile::Base.new }
     it "saves generic_file" do
-      described_class.call(generic_file, path, type)
+      described_class.call(generic_file, file, type)
       expect(generic_file.persisted?).to be true
     end
   end
@@ -23,28 +26,40 @@ describe Hydra::Works::AddFileToGenericFile do
       allow(generic_file).to receive(:valid?).and_return(false)
     end
     it "returns false" do
-      expect( described_class.call(generic_file, path, type) ).to be false
+      expect( described_class.call(generic_file, file, type) ).to be false
     end
   end
 
-  context "when you provide mime_type and original_name" do
-    before { described_class.call(generic_file, path, type, mime_type: "image/png", original_name:'chosen_filename.txt') }
+  context "file responds to :mime_type and :original_name" do
+    before do
+      allow(file).to         receive(:mime_type).and_return(mime_type)
+      allow(file).to         receive(:original_name).and_return(original_name)
+      described_class.call(generic_file, file, type)
+    end
     subject { generic_file.filter_files_by_type(type).first }
-    it "uses the provided values" do
-      expect(subject.mime_type).to eq('image/png')
-      expect(subject.original_name).to eq('chosen_filename.txt')
+    it "uses the mime_type and original_name methods" do
+      expect(subject.mime_type).to eq(mime_type)
+      expect(subject.original_name).to eq(original_name)
+    end
+  end
+
+  context "file responds to :path but not to :mime_type nor :original_name" do
+    it "defaults to Hydra::PCDM for mimetype and ::File for basename." do
+    expect(Hydra::PCDM::GetMimeTypeForFile).to receive(:call).with(file.path)
+    expect(::File).to receive(:basename).with(file.path)
+    described_class.call(generic_file, file, type)
     end
   end
 
   it "adds the given file and applies the specified type to it" do
-    described_class.call(generic_file, path, type, update_existing: update_existing)
+    described_class.call(generic_file, file, type, update_existing: update_existing)
     expect(generic_file.filter_files_by_type(type).first.content).to start_with("%PDF-1.3")
   end
 
   context "when :type is the name of an association" do
     let(:type)  { :extracted_text }
     before do
-      described_class.call(generic_file, path, type)
+      described_class.call(generic_file, file, type)
     end
     it "builds and uses the association's target" do
       expect(generic_file.extracted_text.content).to start_with("%PDF-1.3")
@@ -56,14 +71,14 @@ describe Hydra::Works::AddFileToGenericFile do
     let(:versioning)  { true }
     subject     { generic_file }
     it "updates the file and creates a version" do
-      described_class.call(generic_file, path, type, versioning: versioning)
+      described_class.call(generic_file, file, type, versioning: versioning)
       expect(subject.original_file.versions.all.count).to eq(1)
       expect(subject.original_file.content).to start_with("%PDF-1.3")
     end
     context "and there are already versions" do
       before do
-        described_class.call(generic_file, path, type, versioning: versioning)
-        described_class.call(generic_file, path2, type, versioning: versioning)
+        described_class.call(generic_file, file, type, versioning: versioning)
+        described_class.call(generic_file, file2, type, versioning: versioning)
       end
       it "adds to the version history" do
         expect(subject.original_file.versions.all.count).to eq(2)
@@ -76,7 +91,7 @@ describe Hydra::Works::AddFileToGenericFile do
     let(:type)        { :original_file }
     let(:versioning)  { false }
     before do
-      described_class.call(generic_file, path, type, versioning: versioning)
+      described_class.call(generic_file, file, type, versioning: versioning)
     end
     subject     { generic_file }
     it "skips creating versions" do

--- a/spec/hydra/works/services/generic_file/persist_derivative_spec.rb
+++ b/spec/hydra/works/services/generic_file/persist_derivative_spec.rb
@@ -4,19 +4,17 @@ describe Hydra::Works::PersistDerivative do
 
   let(:generic_file)        { Hydra::Works::GenericFile::Base.new }
   let(:filename)            { "sample-file.pdf" }
-  let(:destination_name)    { File.join(fixture_path, filename) }
-  let(:file)                { File.new(destination_name) }
+  let(:file)                { File.open(File.join(fixture_path, filename)) }
   let(:type)                { ::RDF::URI("http://pcdm.org/use#ExtractedText") }
   let(:service_type)        { ::RDF::URI("http://pcdm.org/use#ServiceFile") }
 
-
   it "persists a service file by default" do
-    Hydra::Works::PersistDerivative.call(generic_file, file, destination_name)
+    Hydra::Works::PersistDerivative.call(generic_file, file)
     expect(generic_file.filter_files_by_type(service_type).first.content).to start_with("%PDF-1.3")
   end
 
   it "persists a dervivative as a specified type" do
-    Hydra::Works::PersistDerivative.call(generic_file, file, destination_name, type: type)
+    Hydra::Works::PersistDerivative.call(generic_file, file, type: type)
     expect(generic_file.filter_files_by_type(type).first.content).to start_with("%PDF-1.3")
   end
 

--- a/spec/hydra/works/services/generic_file/upload_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/upload_file_spec.rb
@@ -4,22 +4,22 @@ describe Hydra::Works::UploadFileToGenericFile do
 
   let(:generic_work)        { Hydra::Works::GenericWork::Base.new }
   let(:generic_file)        { Hydra::Works::GenericFile::Base.new }
-  let(:filename)            { "sample-file.pdf" }
-  let(:file)                { File.join(fixture_path, filename) }
-  let(:updated_filename)    { "updated-file.txt"}
-  let(:updated_file)        { File.join(fixture_path, updated_filename) }
+  let(:file)                { File.open(File.join(fixture_path, "sample-file.pdf")) }
+  let(:updated_file)        { File.open(File.join(fixture_path, "updated-file.txt")) }
   let(:mime_type)           { "application/pdf" }
   let(:original_name)       { "my_original.pdf" }
   let(:updated_mime_type)   { "text/plain" }
+  let(:updated_name)        { "my_updated.txt" }
   let(:additional_services) { [Hydra::Works::GenerateThumbnail] }
 
   context "when you provide mime_type and original_name, etc" do
     it "uses the provided values" do
-      expect(Hydra::Works::AddFileToGenericFile).to receive(:call).with(generic_file, file, :original_file, update_existing: true, versioning: true, mime_type:mime_type, original_name:original_name)
-      described_class.call(generic_file, file, mime_type: mime_type, original_name:original_name)
+      expect(Hydra::Works::AddFileToGenericFile).to receive(:call).with(generic_file, file, :original_file, update_existing: true, versioning: true )
+      described_class.call(generic_file, file )
     end
   end
 
+  # Duplicate test from add_file_spec
   context "without a proper generic file" do
     let(:error_message) { "supplied object must be a generic file" }
     it "raises an error" do
@@ -27,29 +27,40 @@ describe Hydra::Works::UploadFileToGenericFile do
     end
   end
 
-  context "without a proper path" do
-    let(:error_message) { "supplied path must be a string" }
+  # Duplicate test from add_file_spec
+  context "without file that responds to read." do
+    let(:error_message) { "supplied file must respond to read" }
     it "raises an error" do
-      expect( lambda { described_class.call(generic_file, ["this isn't a path"]) }).to raise_error(ArgumentError, error_message)
-    end
-  end
-
-  context "with a non-existent file" do
-    let(:error_message) { "supplied path to file does not exist" }
-    it "raises an error" do
-      expect( lambda { described_class.call(generic_file, "/i/do/not/exist") }).to raise_error(ArgumentError, error_message)
+      expect( lambda { described_class.call(generic_file, ["this does not respond to read."]) }).to raise_error(ArgumentError, error_message)
     end
   end
 
   context "with an empty generic file" do
-    before { described_class.call(generic_file, file, additional_services: additional_services) }
+    before do 
+      allow(file).to         receive(:mime_type).and_return(mime_type)
+      allow(file).to         receive(:original_name).and_return(original_name)
+      described_class.call(generic_file, file, additional_services: additional_services) 
+    end
 
     describe "the uploaded file" do
+      subject { generic_file.original_file }
+      it "has content" do
+        expect(subject.content).to start_with("%PDF-1.3")
+      end
+      it "has a mime type" do
+        expect(subject.mime_type).to eql mime_type
+      end
+      it "has a name" do
+        expect(subject.original_name).to eql original_name
+      end
+    end
+
+    describe "the generic file's generated files" do
       subject { generic_file }
       it "has content and generated files" do
         expect(subject.original_file.content).to start_with("%PDF-1.3")
         expect(subject.original_file.mime_type).to eql mime_type
-        expect(subject.original_file.original_name).to eql filename
+        expect(subject.original_file.original_name).to eql original_name
         expect(subject.thumbnail.content).not_to be_nil
       end
     end
@@ -59,6 +70,11 @@ describe Hydra::Works::UploadFileToGenericFile do
     let(:additional_services) { [] }
 
     before do
+      allow(file).to         receive(:mime_type).and_return(mime_type)
+      allow(file).to         receive(:original_name).and_return(original_name)
+      allow(updated_file).to         receive(:mime_type).and_return(updated_mime_type)
+      allow(updated_file).to         receive(:original_name).and_return(updated_name)
+
       described_class.call(generic_file, file, additional_services: additional_services)
       described_class.call(generic_file, updated_file, additional_services: additional_services, update_existing: true)
     end
@@ -66,8 +82,13 @@ describe Hydra::Works::UploadFileToGenericFile do
     describe "the new file" do
       subject { generic_file.original_file }
       it "has updated content" do
-        expect(subject.content).to eql File.open(updated_file).read
-        expect(subject.original_name).to eql updated_filename
+        updated_file.rewind
+        expect(subject.content).to eql updated_file.read
+      end
+      it "has an updated name" do
+        expect(subject.original_name).to eql updated_name
+      end
+      it "has a updated mime type" do
         expect(subject.mime_type).to eql updated_mime_type
         expect(subject.versions.all.count).to eql 2
       end


### PR DESCRIPTION
Refactor file check to responds_to? :read.
If present use :mime_type and :original_name of file.
Add metadata defaults depending on available methods.
Add test for technical metadata defaults for AddFileToGenericFile.

Change PersistDerivative to use IO in lieu of path.
Remove desination_name from call signature in PersistDerivative.
Refactor UploadFile to use IO in lieu of path.

Remove argument checks from UploadFile. They are done in
AddFileToGenericFile.
Remove mime_type and original_name from args of UploadFile.

Update specs to pass File object instead of path.
Mock methods :mime_type and :original_name for testing Files.

