### PR TITLE
Improving test performance

### DIFF
--- a/spec/hydra/works/models/concerns/generic_file/contained_files_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file/contained_files_spec.rb
@@ -16,7 +16,6 @@ describe Hydra::Works::GenericFile::ContainedFiles do
 
   before do
     generic_file.files = [file]
-    generic_file.save
   end
 
   describe "#thumbnail" do
@@ -25,8 +24,6 @@ describe Hydra::Works::GenericFile::ContainedFiles do
       before do
         original_file = generic_file.build_thumbnail
         original_file.content = "thumbnail"
-        generic_file.save
-        generic_file.reload
       end
       subject { generic_file.thumbnail }
       it "can be saved without errors" do
@@ -58,8 +55,6 @@ describe Hydra::Works::GenericFile::ContainedFiles do
       before do
         original_file = generic_file.build_original_file
         original_file.content = "original_file"
-        generic_file.save
-        generic_file.reload
       end
       subject { generic_file.original_file }
 
@@ -93,8 +88,6 @@ describe Hydra::Works::GenericFile::ContainedFiles do
       before do
         extracted_text = generic_file.build_extracted_text
         extracted_text.content = "extracted_text"
-        generic_file.save
-        generic_file.reload
       end
       subject { generic_file.extracted_text }
       it "can be saved without errors" do

--- a/spec/hydra/works/models/concerns/generic_file/versioned_content_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file/versioned_content_spec.rb
@@ -1,23 +1,22 @@
 require 'spec_helper'
 
 describe Hydra::Works::GenericFile::VersionedContent do
-  let(:generic_file)  { Hydra::Works::GenericFile::Base.create }
-  let(:reloaded)      { generic_file.reload }
+  let(:generic_file)  { Hydra::Works::GenericFile::Base.new }
   before do
     Hydra::Works::UploadFileToGenericFile.call(generic_file, File.join(fixture_path, "sample-file.pdf"))
     Hydra::Works::UploadFileToGenericFile.call(generic_file, File.join(fixture_path, "updated-file.txt"))
   end
 
   describe "content_versions" do
-    subject {reloaded.content_versions}
+    subject {generic_file.content_versions}
     it "lists all of the versions of original_file" do
       expect(subject.count).to eq(2)
-      expect(subject.map { |v| v.uri }).to eq(reloaded.original_file.versions.all.map { |v| v.uri })
+      expect(subject.map { |v| v.uri }).to eq(generic_file.original_file.versions.all.map { |v| v.uri })
     end
   end
 
   describe "latest_content_version" do
-    subject { reloaded.latest_content_version }
+    subject { generic_file.latest_content_version }
     it "returns the most recent version entry for original_file" do
       # Can't use a simple equivalence because they are actually different ResourceVersion objects
       expect(subject.uri).to eq(generic_file.original_file.versions.last.uri)

--- a/spec/hydra/works/services/collection/remove_collection_spec.rb
+++ b/spec/hydra/works/services/collection/remove_collection_spec.rb
@@ -24,26 +24,25 @@ describe Hydra::Works::RemoveCollectionFromCollection do
         Hydra::Works::AddCollectionToCollection.call( subject, collection4 )
         Hydra::Works::AddGenericWorkToCollection.call( subject, generic_work1 )
         Hydra::Works::AddCollectionToCollection.call( subject, collection5 )
-        subject.save
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection1,collection2,collection3,collection4,collection5]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection1,collection2,collection3,collection4,collection5]
       end
 
       it 'should remove first collection' do
         expect( Hydra::Works::RemoveCollectionFromCollection.call( subject, collection1 ) ).to eq collection1
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection2,collection3,collection4,collection5]
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection2,collection3,collection4,collection5]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work2,generic_work1]
       end
 
       it 'should remove last collection' do
         expect( Hydra::Works::RemoveCollectionFromCollection.call( subject, collection5 ) ).to eq collection5
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection1,collection2,collection3,collection4]
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection1,collection2,collection3,collection4]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work2,generic_work1]
       end
 
       it 'should remove middle collection' do
         expect( Hydra::Works::RemoveCollectionFromCollection.call( subject, collection3 ) ).to eq collection3
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection1,collection2,collection4,collection5]
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection1,collection2,collection4,collection5]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work2,generic_work1]
       end
     end
   end

--- a/spec/hydra/works/services/collection/remove_generic_work_spec.rb
+++ b/spec/hydra/works/services/collection/remove_generic_work_spec.rb
@@ -24,26 +24,25 @@ describe Hydra::Works::RemoveGenericWorkFromCollection do
         Hydra::Works::AddGenericWorkToCollection.call( subject, generic_work4 )
         Hydra::Works::AddCollectionToCollection.call( subject, collection1 )
         Hydra::Works::AddGenericWorkToCollection.call( subject, generic_work5 )
-        subject.save
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work1,generic_work2,generic_work3,generic_work4,generic_work5]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work1,generic_work2,generic_work3,generic_work4,generic_work5]
       end
 
       it 'should remove first generic work' do
         expect( Hydra::Works::RemoveGenericWorkFromCollection.call( subject, generic_work1 ) ).to eq generic_work1
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work2,generic_work3,generic_work4,generic_work5]
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection2,collection1]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work2,generic_work3,generic_work4,generic_work5]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection2,collection1]
       end
 
       it 'should remove last generic work' do
         expect( Hydra::Works::RemoveGenericWorkFromCollection.call( subject, generic_work5 ) ).to eq generic_work5
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work1,generic_work2,generic_work3,generic_work4]
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection2,collection1]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work1,generic_work2,generic_work3,generic_work4]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection2,collection1]
       end
 
       it 'should remove middle generic work' do
         expect( Hydra::Works::RemoveGenericWorkFromCollection.call( subject, generic_work3 ) ).to eq generic_work3
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work1,generic_work2,generic_work4,generic_work5]
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection2,collection1]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work1,generic_work2,generic_work4,generic_work5]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection2,collection1]
       end
     end
   end

--- a/spec/hydra/works/services/collection/remove_related_object_spec.rb
+++ b/spec/hydra/works/services/collection/remove_related_object_spec.rb
@@ -26,29 +26,28 @@ describe Hydra::Works::RemoveRelatedObjectFromCollection do
         Hydra::Works::AddRelatedObjectToCollection.call( subject, related_object4 )
         Hydra::Works::AddCollectionToCollection.call( subject, collection1 )
         Hydra::Works::AddRelatedObjectToCollection.call( subject, related_work5 )
-        subject.save
-        expect( Hydra::Works::GetRelatedObjectsFromCollection.call( subject.reload )).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
+        expect( Hydra::Works::GetRelatedObjectsFromCollection.call( subject )).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
       end
 
       it 'should remove first related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromCollection.call( subject, related_object1 ) ).to eq related_object1
-        expect( Hydra::Works::GetRelatedObjectsFromCollection.call( subject.reload )).to eq [related_work2,related_file3,related_object4,related_work5]
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection2,collection1]
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work1]
+        expect( Hydra::Works::GetRelatedObjectsFromCollection.call( subject )).to eq [related_work2,related_file3,related_object4,related_work5]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection2,collection1]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work1]
       end
 
       it 'should remove last related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromCollection.call( subject, related_work5 ) ).to eq related_work5
-        expect( Hydra::Works::GetRelatedObjectsFromCollection.call( subject.reload )).to eq [related_object1,related_work2,related_file3,related_object4]
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection2,collection1]
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work1]
+        expect( Hydra::Works::GetRelatedObjectsFromCollection.call( subject )).to eq [related_object1,related_work2,related_file3,related_object4]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection2,collection1]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work1]
       end
 
       it 'should remove middle related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromCollection.call( subject, related_file3 ) ).to eq related_file3
-        expect( Hydra::Works::GetRelatedObjectsFromCollection.call( subject.reload )).to eq [related_object1,related_work2,related_object4,related_work5]
-        expect( Hydra::Works::GetCollectionsFromCollection.call( subject.reload )).to eq [collection2,collection1]
-        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject.reload )).to eq [generic_work1]
+        expect( Hydra::Works::GetRelatedObjectsFromCollection.call( subject )).to eq [related_object1,related_work2,related_object4,related_work5]
+        expect( Hydra::Works::GetCollectionsFromCollection.call( subject )).to eq [collection2,collection1]
+        expect( Hydra::Works::GetGenericWorksFromCollection.call( subject )).to eq [generic_work1]
       end
     end
   end

--- a/spec/hydra/works/services/generic_file/add_file_to_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_file_to_generic_file_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Hydra::Works::AddFileToGenericFile do
 
   let(:generic_file)        { Hydra::Works::GenericFile::Base.new }
-  let(:reloaded)            { generic_file.reload }
   let(:filename)            { "sample-file.pdf" }
   let(:path)                { File.join(fixture_path, filename) }
   let(:path2)               { File.join(fixture_path, "updated-file.txt") }
@@ -48,14 +47,14 @@ describe Hydra::Works::AddFileToGenericFile do
       described_class.call(generic_file, path, type)
     end
     it "builds and uses the association's target" do
-      expect(reloaded.extracted_text.content).to start_with("%PDF-1.3")
+      expect(generic_file.extracted_text.content).to start_with("%PDF-1.3")
     end
   end
 
   context "when :versioning => true" do
     let(:type)        { :original_file }
     let(:versioning)  { true }
-    subject     { reloaded }
+    subject     { generic_file }
     it "updates the file and creates a version" do
       described_class.call(generic_file, path, type, versioning: versioning)
       expect(subject.original_file.versions.all.count).to eq(1)
@@ -79,7 +78,7 @@ describe Hydra::Works::AddFileToGenericFile do
     before do
       described_class.call(generic_file, path, type, versioning: versioning)
     end
-    subject     { reloaded }
+    subject     { generic_file }
     it "skips creating versions" do
       expect(subject.original_file.versions.all.count).to eq(0)
       expect(subject.original_file.content).to start_with("%PDF-1.3")

--- a/spec/hydra/works/services/generic_file/add_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_generic_file_spec.rb
@@ -36,7 +36,6 @@ describe Hydra::Works::AddGenericFileToGenericFile do
           file2.content = "I am too"
           Hydra::Works::AddGenericFileToGenericFile.call( subject, generic_file1 )
           Hydra::Works::AddGenericFileToGenericFile.call( subject, generic_file2 )
-          subject.save!
         end
 
         it 'should add generic_file to generic_file with generic_files and files' do

--- a/spec/hydra/works/services/generic_file/add_related_object_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_related_object_spec.rb
@@ -35,7 +35,6 @@ describe Hydra::Works::AddRelatedObjectToGenericFile do
           file2.content = "I am too"
           Hydra::Works::AddGenericFileToGenericFile.call( subject, generic_file1 )
           Hydra::Works::AddRelatedObjectToGenericFile.call( subject, object1 )
-          subject.save!
         end
 
         it 'should add a related object to a generic_file with files and generic_files' do

--- a/spec/hydra/works/services/generic_file/remove_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/remove_generic_file_spec.rb
@@ -18,23 +18,22 @@ describe Hydra::Works::RemoveGenericFileFromGenericFile do
         Hydra::Works::AddGenericFileToGenericFile.call( subject, generic_file3 )
         Hydra::Works::AddGenericFileToGenericFile.call( subject, generic_file4 )
         Hydra::Works::AddGenericFileToGenericFile.call( subject, generic_file5 )
-        subject.save
-        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject.reload )).to eq [generic_file1,generic_file2,generic_file3,generic_file4,generic_file5]
+        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject )).to eq [generic_file1,generic_file2,generic_file3,generic_file4,generic_file5]
       end
 
       it 'should remove first collection' do
         expect( Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, generic_file1 ) ).to eq generic_file1
-        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject.reload )).to eq [generic_file2,generic_file3,generic_file4,generic_file5]
+        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject )).to eq [generic_file2,generic_file3,generic_file4,generic_file5]
       end
 
       it 'should remove last collection' do
         expect( Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, generic_file5 ) ).to eq generic_file5
-        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject.reload )).to eq [generic_file1,generic_file2,generic_file3,generic_file4]
+        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject )).to eq [generic_file1,generic_file2,generic_file3,generic_file4]
       end
 
       it 'should remove middle collection' do
         expect( Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, generic_file3 ) ).to eq generic_file3
-        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject.reload )).to eq [generic_file1,generic_file2,generic_file4,generic_file5]
+        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject )).to eq [generic_file1,generic_file2,generic_file4,generic_file5]
       end
     end
   end

--- a/spec/hydra/works/services/generic_file/remove_related_object_spec.rb
+++ b/spec/hydra/works/services/generic_file/remove_related_object_spec.rb
@@ -24,26 +24,25 @@ describe Hydra::Works::RemoveRelatedObjectFromGenericFile do
         Hydra::Works::AddRelatedObjectToGenericFile.call( subject, related_object4 )
         Hydra::Works::AddGenericFileToGenericFile.call( subject, generic_file1 )
         Hydra::Works::AddRelatedObjectToGenericFile.call( subject, related_work5 )
-        subject.save
-        expect( Hydra::Works::GetRelatedObjectsFromGenericFile.call( subject.reload )).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
+        expect( Hydra::Works::GetRelatedObjectsFromGenericFile.call( subject )).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
       end
 
       it 'should remove first related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromGenericFile.call( subject, related_object1 ) ).to eq related_object1
-        expect( Hydra::Works::GetRelatedObjectsFromGenericFile.call( subject.reload )).to eq [related_work2,related_file3,related_object4,related_work5]
-        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject.reload )).to eq [generic_file2,generic_file1]
+        expect( Hydra::Works::GetRelatedObjectsFromGenericFile.call( subject )).to eq [related_work2,related_file3,related_object4,related_work5]
+        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject )).to eq [generic_file2,generic_file1]
       end
 
       it 'should remove last related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromGenericFile.call( subject, related_work5 ) ).to eq related_work5
-        expect( Hydra::Works::GetRelatedObjectsFromGenericFile.call( subject.reload )).to eq [related_object1,related_work2,related_file3,related_object4]
-        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject.reload )).to eq [generic_file2,generic_file1]
+        expect( Hydra::Works::GetRelatedObjectsFromGenericFile.call( subject )).to eq [related_object1,related_work2,related_file3,related_object4]
+        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject )).to eq [generic_file2,generic_file1]
       end
 
       it 'should remove middle related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromGenericFile.call( subject, related_file3 ) ).to eq related_file3
-        expect( Hydra::Works::GetRelatedObjectsFromGenericFile.call( subject.reload )).to eq [related_object1,related_work2,related_object4,related_work5]
-        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject.reload )).to eq [generic_file2,generic_file1]
+        expect( Hydra::Works::GetRelatedObjectsFromGenericFile.call( subject )).to eq [related_object1,related_work2,related_object4,related_work5]
+        expect( Hydra::Works::GetGenericFilesFromGenericFile.call( subject )).to eq [generic_file2,generic_file1]
       end
     end
   end

--- a/spec/hydra/works/services/generic_file/upload_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/upload_file_spec.rb
@@ -45,21 +45,11 @@ describe Hydra::Works::UploadFileToGenericFile do
     before { described_class.call(generic_file, file, additional_services: additional_services) }
 
     describe "the uploaded file" do
-      subject { generic_file.original_file }
-      it "has content" do
-        expect(subject.content).to start_with("%PDF-1.3")
-      end
-      it "has a mime type" do
-        expect(subject.mime_type).to eql mime_type
-      end
-      it "has a name" do
-        expect(subject.original_name).to eql filename
-      end
-    end
-
-    describe "the generic file's generated files" do
       subject { generic_file }
-      it "has a thumbnail" do
+      it "has content and generated files" do
+        expect(subject.original_file.content).to start_with("%PDF-1.3")
+        expect(subject.original_file.mime_type).to eql mime_type
+        expect(subject.original_file.original_name).to eql filename
         expect(subject.thumbnail.content).not_to be_nil
       end
     end
@@ -71,21 +61,14 @@ describe Hydra::Works::UploadFileToGenericFile do
     before do
       described_class.call(generic_file, file, additional_services: additional_services)
       described_class.call(generic_file, updated_file, additional_services: additional_services, update_existing: true)
-      generic_file.reload
     end
 
     describe "the new file" do
       subject { generic_file.original_file }
       it "has updated content" do
         expect(subject.content).to eql File.open(updated_file).read
-      end
-      it "has an updated name" do
         expect(subject.original_name).to eql updated_filename
-      end
-      it "has a updated mime type" do
         expect(subject.mime_type).to eql updated_mime_type
-      end
-      it "has 2 versions in its history" do
         expect(subject.versions.all.count).to eql 2
       end
     end

--- a/spec/hydra/works/services/generic_work/remove_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_work/remove_generic_file_spec.rb
@@ -23,26 +23,25 @@ describe Hydra::Works::RemoveGenericFileFromGenericWork do
         Hydra::Works::AddGenericFileToGenericWork.call( subject, generic_file4 )
         Hydra::Works::AddGenericWorkToGenericWork.call( subject, generic_work1 )
         Hydra::Works::AddGenericFileToGenericWork.call( subject, generic_file5 )
-        subject.save
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file1,generic_file2,generic_file3,generic_file4,generic_file5]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file1,generic_file2,generic_file3,generic_file4,generic_file5]
       end
 
       it 'should remove first collection' do
         expect( Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, generic_file1 ) ).to eq generic_file1
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file2,generic_file3,generic_file4,generic_file5]
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file2,generic_file3,generic_file4,generic_file5]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work2,generic_work1]
       end
 
       it 'should remove last collection' do
         expect( Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, generic_file5 ) ).to eq generic_file5
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file1,generic_file2,generic_file3,generic_file4]
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file1,generic_file2,generic_file3,generic_file4]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work2,generic_work1]
       end
 
       it 'should remove middle collection' do
         expect( Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, generic_file3 ) ).to eq generic_file3
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file1,generic_file2,generic_file4,generic_file5]
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file1,generic_file2,generic_file4,generic_file5]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work2,generic_work1]
       end
     end
   end

--- a/spec/hydra/works/services/generic_work/remove_generic_work_spec.rb
+++ b/spec/hydra/works/services/generic_work/remove_generic_work_spec.rb
@@ -24,26 +24,25 @@ describe Hydra::Works::RemoveGenericWorkFromGenericWork do
         Hydra::Works::AddGenericWorkToGenericWork.call( subject, generic_work4 )
         Hydra::Works::AddGenericFileToGenericWork.call( subject, generic_file1 )
         Hydra::Works::AddGenericWorkToGenericWork.call( subject, generic_work5 )
-        subject.save
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work1,generic_work2,generic_work3,generic_work4,generic_work5]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work1,generic_work2,generic_work3,generic_work4,generic_work5]
       end
 
       it 'should remove first collection' do
         expect( Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, generic_work1 ) ).to eq generic_work1
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work2,generic_work3,generic_work4,generic_work5]
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file2,generic_file1]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work2,generic_work3,generic_work4,generic_work5]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file2,generic_file1]
       end
 
       it 'should remove last collection' do
         expect( Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, generic_work5 ) ).to eq generic_work5
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work1,generic_work2,generic_work3,generic_work4]
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file2,generic_file1]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work1,generic_work2,generic_work3,generic_work4]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file2,generic_file1]
       end
 
       it 'should remove middle collection' do
         expect( Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, generic_work3 ) ).to eq generic_work3
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work1,generic_work2,generic_work4,generic_work5]
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file2,generic_file1]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work1,generic_work2,generic_work4,generic_work5]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file2,generic_file1]
       end
     end
   end

--- a/spec/hydra/works/services/generic_work/remove_related_object_spec.rb
+++ b/spec/hydra/works/services/generic_work/remove_related_object_spec.rb
@@ -26,29 +26,28 @@ describe Hydra::Works::RemoveRelatedObjectFromGenericWork do
         Hydra::Works::AddRelatedObjectToGenericWork.call( subject, related_object4 )
         Hydra::Works::AddGenericWorkToGenericWork.call( subject, generic_work1 )
         Hydra::Works::AddRelatedObjectToGenericWork.call( subject, related_work5 )
-        subject.save
-        expect( Hydra::Works::GetRelatedObjectsFromGenericWork.call( subject.reload )).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
+        expect( Hydra::Works::GetRelatedObjectsFromGenericWork.call( subject )).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
       end
 
       it 'should remove first related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromGenericWork.call( subject, related_object1 ) ).to eq related_object1
-        expect( Hydra::Works::GetRelatedObjectsFromGenericWork.call( subject.reload )).to eq [related_work2,related_file3,related_object4,related_work5]
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work2,generic_work1]
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file1]
+        expect( Hydra::Works::GetRelatedObjectsFromGenericWork.call( subject )).to eq [related_work2,related_file3,related_object4,related_work5]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file1]
       end
 
       it 'should remove last related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromGenericWork.call( subject, related_work5 ) ).to eq related_work5
-        expect( Hydra::Works::GetRelatedObjectsFromGenericWork.call( subject.reload )).to eq [related_object1,related_work2,related_file3,related_object4]
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work2,generic_work1]
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file1]
+        expect( Hydra::Works::GetRelatedObjectsFromGenericWork.call( subject )).to eq [related_object1,related_work2,related_file3,related_object4]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file1]
       end
 
       it 'should remove middle related object' do
         expect( Hydra::Works::RemoveRelatedObjectFromGenericWork.call( subject, related_file3 ) ).to eq related_file3
-        expect( Hydra::Works::GetRelatedObjectsFromGenericWork.call( subject.reload )).to eq [related_object1,related_work2,related_object4,related_work5]
-        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject.reload )).to eq [generic_work2,generic_work1]
-        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject.reload )).to eq [generic_file1]
+        expect( Hydra::Works::GetRelatedObjectsFromGenericWork.call( subject )).to eq [related_object1,related_work2,related_object4,related_work5]
+        expect( Hydra::Works::GetGenericWorksFromGenericWork.call( subject )).to eq [generic_work2,generic_work1]
+        expect( Hydra::Works::GetGenericFilesFromGenericWork.call( subject )).to eq [generic_file1]
       end
     end
   end


### PR DESCRIPTION
Fixes #148 

* Removing unnecessary saves and reloads
* Combining a few tests that need to save objects to avoid repeated object creation
* On my machine, reduces test duration from 268 to 45 sec (~6x faster)