### PR TITLE
use filters, parent/child API, indexers, deprecate services

### DIFF
--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -24,6 +24,7 @@ module Hydra
     autoload :AggregatesGenericWorks, 'hydra/works/models/concerns/aggregates_generic_works'
     autoload :AggregatesCollections,  'hydra/works/models/concerns/aggregates_collections'
     autoload :GenericFile,            'hydra/works/models/generic_file'
+    autoload :BlockChildObjects,      'hydra/works/models/concerns/block_child_objects'
 
     # collection services
     autoload :AddCollectionToCollection,           'hydra/works/services/collection/add_collection'

--- a/lib/hydra/works/models/concerns/aggregates_collections.rb
+++ b/lib/hydra/works/models/concerns/aggregates_collections.rb
@@ -2,14 +2,18 @@ module Hydra::Works
   # Allows instances of a class to aggregate (pcdm:hasMember) hydra-works collections
   module AggregatesCollections
 
+    def child_collection_ids
+      child_collections.map(&:id)
+    end
+
     def collections= collections
-      raise ArgumentError, "each collection must be a hydra works collection" unless collections.all? { |c| Hydra::Works.collection? c }
-      raise ArgumentError, "a collection can't be an ancestor of itself" if collection_ancestor?(collections)
-      self.members = self.generic_works + collections
+      warn "[DEPRECATION] `collections=` is deprecated.  Please use `child_collections=` instead.  This has a target date for removal of 07-31-2015"
+      self.child_collections = collections
     end
 
     def collections
-      members.to_a.select { |m| Hydra::Works.collection? m }
+      warn "[DEPRECATION] `collections` is deprecated.  Please use `child_collections` instead.  This has a target date for removal of 07-31-2015"
+      self.child_collections
     end
 
   end

--- a/lib/hydra/works/models/concerns/aggregates_generic_files.rb
+++ b/lib/hydra/works/models/concerns/aggregates_generic_files.rb
@@ -2,18 +2,18 @@ module Hydra::Works
   # Allows instances of a class to aggregate (pcdm:hasMember) hydra-works generic files
   module AggregatesGenericFiles
 
+    def child_generic_file_ids
+      child_generic_files.map(&:id)
+    end
+
     def generic_files= generic_files
-      raise ArgumentError, "each generic_file must be a hydra works generic file" unless generic_files.all? { |w| Hydra::Works.generic_file? w }
-      raise ArgumentError, "a generic file can't be an ancestor of itself" if object_ancestor?(generic_files)
-      if self.respond_to?(:generic_works)
-        self.members = self.generic_works + generic_files
-      else
-        self.members = generic_files
-      end
+      warn "[DEPRECATION] `generic_files=` is deprecated.  Please use `child_generic_files=` instead.  This has a target date for removal of 07-31-2015"
+      self.child_generic_files = generic_files
     end
 
     def generic_files
-      members.to_a.select { |m| Hydra::Works.generic_file? m }
+      warn "[DEPRECATION] `generic_files` is deprecated.  Please use `child_generic_files` instead.  This has a target date for removal of 07-31-2015"
+      self.child_generic_files
     end
   end
 

--- a/lib/hydra/works/models/concerns/aggregates_generic_works.rb
+++ b/lib/hydra/works/models/concerns/aggregates_generic_works.rb
@@ -2,18 +2,18 @@ module Hydra::Works
   # Allows instances of a class to aggregate (pcdm:hasMember) hydra-works generic works
   module AggregatesGenericWorks
 
+    def child_generic_work_ids
+      child_generic_works.map(&:id)
+    end
+
     def generic_works= generic_works
-      raise ArgumentError, "each generic_work must be a hydra works generic work" unless generic_works.all? { |w| Hydra::Works.generic_work? w }
-      raise ArgumentError, "a generic work can't be an ancestor of itself" if self.respond_to?(:object_ancestor?) && object_ancestor?(generic_works)
-      if self.respond_to?(:generic_files)
-        self.members = self.generic_files + generic_works
-      else
-        self.members = generic_works
-      end
+      warn "[DEPRECATION] `generic_works=` is deprecated.  Please use `child_generic_works=` instead.  This has a target date for removal of 07-31-2015"
+      self.child_generic_works = generic_works
     end
 
     def generic_works
-      members.to_a.select { |m| Hydra::Works.generic_work? m }
+      warn "[DEPRECATION] `generic_works` is deprecated.  Please use `child_generic_works` instead.  This has a target date for removal of 07-31-2015"
+      self.child_generic_works
     end
 
   end

--- a/lib/hydra/works/models/concerns/block_child_objects.rb
+++ b/lib/hydra/works/models/concerns/block_child_objects.rb
@@ -1,0 +1,16 @@
+module Hydra::Works
+  # Do not allow aggregation of child objects
+  module BlockChildObjects
+
+    def child_objects= objects
+      raise StandardError, "method `child_objects=' not allowed for #{self}"
+    end
+
+    def child_objects
+      raise StandardError, "method `child_objects' not allowed for #{self}"
+    end
+
+  end
+end
+
+

--- a/lib/hydra/works/models/concerns/collection_behavior.rb
+++ b/lib/hydra/works/models/concerns/collection_behavior.rb
@@ -22,6 +22,33 @@ module Hydra::Works
       type [RDFVocabularies::PCDMTerms.Collection,WorksVocabularies::WorksTerms.Collection]
       include Hydra::Works::AggregatesGenericWorks
       include Hydra::Works::AggregatesCollections
+      include Hydra::Works::BlockChildObjects
+
+      filters_association :members, as: :child_collections, condition: :works_collection?
+      filters_association :members, as: :child_generic_works, condition: :works_generic_work?
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Collection.
+    def works_collection?
+      true
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+    def works_generic_work?
+      false
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic File.
+    def works_generic_file?
+      false
+    end
+
+    def parents
+      aggregated_by
+    end
+
+    def parent_collections
+      aggregated_by.select { |parent| parent.class.included_modules.include?(Hydra::Works::CollectionBehavior) }
     end
 
   end

--- a/lib/hydra/works/models/concerns/generic_file_behavior.rb
+++ b/lib/hydra/works/models/concerns/generic_file_behavior.rb
@@ -20,6 +20,36 @@ module Hydra::Works
       include Hydra::Works::GenericFile::Derivatives
       include Hydra::Works::GenericFile::MimeTypes
       include Hydra::Works::GenericFile::VersionedContent
+      include Hydra::Works::BlockChildObjects
+
+      filters_association :members, as: :child_generic_files, condition: :works_generic_file?
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Collection.
+    def works_collection?
+      false
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+    def works_generic_work?
+      false
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic File.
+    def works_generic_file?
+      true
+    end
+
+    def parents
+      aggregated_by
+    end
+
+    def parent_generic_works
+      aggregated_by.select { |parent| parent.class.included_modules.include?(Hydra::Works::GenericWorkBehavior) }
+    end
+
+    def parent_generic_files
+      aggregated_by.select { |parent| parent.class.included_modules.include?(Hydra::Works::GenericFileBehavior) }
     end
 
   end

--- a/lib/hydra/works/models/concerns/generic_work_behavior.rb
+++ b/lib/hydra/works/models/concerns/generic_work_behavior.rb
@@ -20,10 +20,41 @@ module Hydra::Works
       type [RDFVocabularies::PCDMTerms.Object,WorksVocabularies::WorksTerms.GenericWork]
       include Hydra::Works::AggregatesGenericFiles
       include Hydra::Works::AggregatesGenericWorks
+      include Hydra::Works::BlockChildObjects
+
+      filters_association :members, as: :child_generic_works, condition: :works_generic_work?
+      filters_association :members, as: :child_generic_files, condition: :works_generic_file?
     end
 
     def contains= files
       raise NoMethodError, "works can not directly contain files.  You must add a GenericFile to the work's members and add files to that GenericFile."
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Collection.
+    def works_collection?
+      false
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+    def works_generic_work?
+      true
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic File.
+    def works_generic_file?
+      false
+    end
+
+    def parents
+      aggregated_by
+    end
+
+    def parent_generic_works
+      aggregated_by.select { |parent| parent.class.included_modules.include?(Hydra::Works::GenericWorkBehavior) }
+    end
+
+    def parent_collections
+      aggregated_by.select { |parent| parent.class.included_modules.include?(Hydra::Works::CollectionBehavior) }
     end
 
   end

--- a/lib/hydra/works/services/collection/add_collection.rb
+++ b/lib/hydra/works/services/collection/add_collection.rb
@@ -10,9 +10,8 @@ module Hydra::Works
     # @return [Hydra::Works::Collection] the updated hydra works collection
 
     def self.call( parent_collection, child_collection )
-      raise ArgumentError, 'parent_collection must be a hydra-works collection' unless Hydra::Works.collection? parent_collection
-      raise ArgumentError, 'child_collection must be a hydra-works collection' unless Hydra::Works.collection? child_collection
-      Hydra::PCDM::AddCollectionToCollection.call( parent_collection, child_collection )
+      warn "[DEPRECATION] `Hydra::Works::AddCollectionToCollection` is deprecated.  Please use syntax `parent_collection.child_collections << child_collection` instead.  This has a target date for removal of 07-31-2015"
+      parent_collection.child_collections << child_collection
     end
 
   end

--- a/lib/hydra/works/services/collection/add_generic_work.rb
+++ b/lib/hydra/works/services/collection/add_generic_work.rb
@@ -10,9 +10,8 @@ module Hydra::Works
     # @return [Hydra::Works::Collection] the updated hydra works collection
 
     def self.call( parent_collection, child_generic_work )
-      raise ArgumentError, 'parent_collection must be a hydra-works collection' unless Hydra::Works.collection? parent_collection
-      raise ArgumentError, 'child_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? child_generic_work
-      Hydra::PCDM::AddObjectToCollection.call( parent_collection, child_generic_work )
+      warn "[DEPRECATION] `Hydra::Works::AddGenericWorkToCollection` is deprecated.  Please use syntax `parent_collection.child_generic_works << child_generic_work` instead.  This has a target date for removal of 07-31-2015"
+      parent_collection.child_generic_works << child_generic_work
     end
 
   end

--- a/lib/hydra/works/services/collection/get_collections.rb
+++ b/lib/hydra/works/services/collection/get_collections.rb
@@ -9,8 +9,8 @@ module Hydra::Works
     # @return [Array<Hydra::Works::Collection>] all member collections
 
     def self.call( parent_collection )
-      raise ArgumentError, 'parent_collection must be a hydra-works collection' unless Hydra::Works.collection? parent_collection
-      parent_collection.collections
+      warn "[DEPRECATION] `Hydra::PCDM::GetCollectionsFromCollection` is deprecated.  Please use syntax `child_collections = parent_collection.child_collections` instead.  NOTE: The new syntax returns an association instead of an array.  This has a target date for removal of 07-31-2015"
+      parent_collection.child_collections.to_a
     end
 
   end

--- a/lib/hydra/works/services/collection/get_generic_works.rb
+++ b/lib/hydra/works/services/collection/get_generic_works.rb
@@ -9,8 +9,8 @@ module Hydra::Works
     # @return [Array<Hydra::Works::GenericWork::Base>] all member generic works
 
     def self.call( parent_collection )
-      raise ArgumentError, 'parent_collection must be a hydra-works collection' unless Hydra::Works.collection? parent_collection
-      parent_collection.generic_works
+      warn "[DEPRECATION] `Hydra::PCDM::GetGenericWorksFromCollection` is deprecated.  Please use syntax `child_generic_works = parent_collection.child_generic_works` instead.  NOTE: The new syntax returns an association instead of an array.  This has a target date for removal of 07-31-2015"
+      parent_collection.child_generic_works.to_a
     end
 
   end

--- a/lib/hydra/works/services/collection/remove_collection.rb
+++ b/lib/hydra/works/services/collection/remove_collection.rb
@@ -10,10 +10,12 @@ module Hydra::Works
     # @return [Hydra::Works::Collection] the updated hydra works collection
 
     def self.call( parent_collection, child_collection )
-      raise ArgumentError, 'parent_collection must be a hydra-works collection' unless Hydra::Works.collection? parent_collection
-      raise ArgumentError, 'child_collection must be a hydra-works collection' unless Hydra::Works.collection? child_collection
-      Hydra::PCDM::RemoveCollectionFromCollection.call( parent_collection, child_collection )
-    end
+      warn "[DEPRECATION] `Hydra::Works::RemoveCollectionFromCollection` is deprecated.  Please use syntax `parent_collection.child_collections.delete child_collection` instead which returns [child_collection] instead of child_collection.  This has a target date for removal of 07-31-2015"
+      result = parent_collection.child_collections.delete child_collection
+      result = result.first if result.kind_of?(Array) && result.size >= 1      # temporarily done for compatibility with current service object API
+      result
 
+      # TODO FIX when members is empty, members.delete raises ActiveFedora::ObjectNotFoundError "Can't reload an object that hasn't been saved"  (activefedora-aggregation issue #35)
+    end
   end
 end

--- a/lib/hydra/works/services/collection/remove_generic_work.rb
+++ b/lib/hydra/works/services/collection/remove_generic_work.rb
@@ -11,10 +11,16 @@ module Hydra::Works
     # @return [Hydra::Works::Collection] the updated hydra works collection
 
     def self.call( parent_collection, child_generic_work, nth_occurrence=1 )
-      raise ArgumentError, 'parent_collection must be a hydra-works collection' unless Hydra::Works.collection? parent_collection
-      raise ArgumentError, 'child_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? child_generic_work
-      Hydra::PCDM::RemoveObjectFromCollection.call( parent_collection, child_generic_work, nth_occurrence )
-    end
+      warn "[DEPRECATION] `Hydra::Works::RemoveGenericWorkFromCollection` is deprecated.  Please use syntax `parent_collection.child_generic_works.delete child_generic_work` instead which returns [child_generic_work] instead of child_generic_work.  This has a target date for removal of 07-31-2015"
+      result = parent_collection.child_generic_works.delete child_generic_work
+      result = result.first if result.kind_of?(Array) && result.size >= 1      # temporarily done for compatibility with current service object API
+      result
 
+      # TODO FIX when members is empty, members.delete raises ActiveFedora::ObjectNotFoundError "Can't reload an object that hasn't been saved"  (activefedora-aggregation issue #35)
+
+      # TODO -- The same object may be in the list multiple times.  (issue pcdm-102 & AF-Agg-46)
+      #   * How to remove nth occurrence?
+      #   * Default to removing 1st occurrence from the beginning of the list.
+    end
   end
 end

--- a/lib/hydra/works/services/generic_file/add_generic_file.rb
+++ b/lib/hydra/works/services/generic_file/add_generic_file.rb
@@ -10,9 +10,8 @@ module Hydra::Works
     # @return [Hydra::Works::GenericFile::Base] the updated hydra works generic file
 
     def self.call( parent_generic_file, child_generic_file )
-      raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file
-      raise ArgumentError, 'child_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? child_generic_file
-      parent_generic_file.members << child_generic_file
+      warn "[DEPRECATION] `Hydra::Works::AddGenericFileToGenericFile` is deprecated.  Please use syntax `parent_generic_file.child_generic_files << child_generic_file` instead.  This has a target date for removal of 07-31-2015"
+      parent_generic_file.child_generic_files << child_generic_file
     end
   end
 end

--- a/lib/hydra/works/services/generic_file/get_generic_files.rb
+++ b/lib/hydra/works/services/generic_file/get_generic_files.rb
@@ -9,8 +9,8 @@ module Hydra::Works
     # @return [Array<Hydra::Works::GenericFile::Base>] all member generic files
 
     def self.call( parent_generic_file )
-      raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file
-      parent_generic_file.generic_files
+      warn "[DEPRECATION] `Hydra::PCDM::GetGenericFilesFromGenericFile` is deprecated.  Please use syntax `child_generic_files = parent_generic_file.child_generic_files` instead.  NOTE: The new syntax returns an association instead of an array.  This has a target date for removal of 07-31-2015"
+      parent_generic_file.child_generic_files.to_a
     end
 
   end

--- a/lib/hydra/works/services/generic_file/remove_generic_file.rb
+++ b/lib/hydra/works/services/generic_file/remove_generic_file.rb
@@ -11,10 +11,16 @@ module Hydra::Works
     # @return [Hydra::Works::GenericFile::Base] the updated hydra works generic file
 
     def self.call( parent_generic_file, child_generic_file, nth_occurrence=1 )
-      raise ArgumentError, 'parent_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? parent_generic_file
-      raise ArgumentError, 'child_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? child_generic_file
-      Hydra::PCDM::RemoveObjectFromObject.call( parent_generic_file, child_generic_file, nth_occurrence )
-    end
+      warn "[DEPRECATION] `Hydra::Works::RemoveGenericFileFromGenericFile` is deprecated.  Please use syntax `parent_generic_file.child_generic_files.delete child_generic_file` instead which returns [child_generic_file] instead of child_generic_file.  This has a target date for removal of 07-31-2015"
+      result = parent_generic_file.child_generic_files.delete child_generic_file
+      result = result.first if result.kind_of?(Array) && result.size >= 1      # temporarily done for compatibility with current service object API
+      result
 
+      # TODO FIX when members is empty, members.delete raises ActiveFedora::ObjectNotFoundError "Can't reload an object that hasn't been saved"  (activefedora-aggregation issue #35)
+
+      # TODO -- The same object may be in the list multiple times.  (issue pcdm-102 & AF-Agg-46)
+      #   * How to remove nth occurrence?
+      #   * Default to removing 1st occurrence from the beginning of the list.
+    end
   end
 end

--- a/lib/hydra/works/services/generic_work/add_generic_file.rb
+++ b/lib/hydra/works/services/generic_work/add_generic_file.rb
@@ -10,9 +10,8 @@ module Hydra::Works
     # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_generic_file )
-      raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work
-      raise ArgumentError, 'child_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? child_generic_file
-      parent_generic_work.members << child_generic_file
+      warn "[DEPRECATION] `Hydra::Works::AddGenericFileToGenericWork` is deprecated.  Please use syntax `parent_generic_work.child_generic_files << child_generic_file` instead.  This has a target date for removal of 07-31-2015"
+      parent_generic_work.child_generic_files << child_generic_file
     end
   end
 end

--- a/lib/hydra/works/services/generic_work/add_generic_work.rb
+++ b/lib/hydra/works/services/generic_work/add_generic_work.rb
@@ -10,9 +10,8 @@ module Hydra::Works
     # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_generic_work )
-      raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work
-      raise ArgumentError, 'child_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? child_generic_work
-      parent_generic_work.members << child_generic_work
+      warn "[DEPRECATION] `Hydra::Works::AddGenericWorkToGenericWork` is deprecated.  Please use syntax `parent_generic_work.child_generic_works << child_generic_work` instead.  This has a target date for removal of 07-31-2015"
+      parent_generic_work.child_generic_works << child_generic_work
     end
   end
 end

--- a/lib/hydra/works/services/generic_work/get_generic_files.rb
+++ b/lib/hydra/works/services/generic_work/get_generic_files.rb
@@ -9,8 +9,8 @@ module Hydra::Works
     # @return [Array<Hydra::Works::GenericFile::Base>] all member generic files
 
     def self.call( parent_generic_work )
-      raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work
-      parent_generic_work.generic_files
+      warn "[DEPRECATION] `Hydra::PCDM::GetGenericFilesFromGenericWork` is deprecated.  Please use syntax `child_generic_files = parent_generic_work.child_generic_files` instead.  NOTE: The new syntax returns an association instead of an array.  This has a target date for removal of 07-31-2015"
+      parent_generic_work.child_generic_files.to_a
     end
 
   end

--- a/lib/hydra/works/services/generic_work/get_generic_works.rb
+++ b/lib/hydra/works/services/generic_work/get_generic_works.rb
@@ -9,8 +9,8 @@ module Hydra::Works
     # @return [Array<Hydra::Works::GenericWork::Base>] all member generic works
 
     def self.call( parent_generic_work )
-      raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work
-      parent_generic_work.generic_works
+      warn "[DEPRECATION] `Hydra::PCDM::GetGenericWorksFromGenericWork` is deprecated.  Please use syntax `child_generic_works = parent_generic_work.child_generic_works` instead.  NOTE: The new syntax returns an association instead of an array.  This has a target date for removal of 07-31-2015"
+      parent_generic_work.child_generic_works.to_a
     end
 
   end

--- a/lib/hydra/works/services/generic_work/remove_generic_file.rb
+++ b/lib/hydra/works/services/generic_work/remove_generic_file.rb
@@ -11,10 +11,16 @@ module Hydra::Works
     # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_generic_file, nth_occurrence=1 )
-      raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work
-      raise ArgumentError, 'child_generic_file must be a hydra-works generic file' unless Hydra::Works.generic_file? child_generic_file
-      Hydra::PCDM::RemoveObjectFromObject.call( parent_generic_work, child_generic_file, nth_occurrence )
-    end
+      warn "[DEPRECATION] `Hydra::Works::RemoveGenericFileFromGenericWork` is deprecated.  Please use syntax `parent_generic_work.child_generic_files.delete child_generic_file` instead which returns [child_generic_file] instead of child_generic_file.  This has a target date for removal of 07-31-2015"
+      result = parent_generic_work.child_generic_files.delete child_generic_file
+      result = result.first if result.kind_of?(Array) && result.size >= 1      # temporarily done for compatibility with current service object API
+      result
 
+      # TODO FIX when members is empty, members.delete raises ActiveFedora::ObjectNotFoundError "Can't reload an object that hasn't been saved"  (activefedora-aggregation issue #35)
+
+      # TODO -- The same object may be in the list multiple times.  (issue pcdm-102 & AF-Agg-46)
+      #   * How to remove nth occurrence?
+      #   * Default to removing 1st occurrence from the beginning of the list.
+    end
   end
 end

--- a/lib/hydra/works/services/generic_work/remove_generic_work.rb
+++ b/lib/hydra/works/services/generic_work/remove_generic_work.rb
@@ -11,10 +11,16 @@ module Hydra::Works
     # @return [Hydra::Works::GenericWork::Base] the updated hydra works generic work
 
     def self.call( parent_generic_work, child_generic_work, nth_occurrence=1 )
-      raise ArgumentError, 'parent_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? parent_generic_work
-      raise ArgumentError, 'child_generic_work must be a hydra-works generic work' unless Hydra::Works.generic_work? child_generic_work
-      Hydra::PCDM::RemoveObjectFromObject.call( parent_generic_work, child_generic_work, nth_occurrence )
-    end
+      warn "[DEPRECATION] `Hydra::Works::RemoveGenericWorkFromGenericWork` is deprecated.  Please use syntax `parent_generic_work.child_generic_works.delete child_generic_work` instead which returns [child_generic_work] instead of child_generic_work.  This has a target date for removal of 07-31-2015"
+      result = parent_generic_work.child_generic_works.delete child_generic_work
+      result = result.first if result.kind_of?(Array) && result.size >= 1      # temporarily done for compatibility with current service object API
+      result
 
+      # TODO FIX when members is empty, members.delete raises ActiveFedora::ObjectNotFoundError "Can't reload an object that hasn't been saved"  (activefedora-aggregation issue #35)
+
+      # TODO -- The same object may be in the list multiple times.  (issue pcdm-102 & AF-Agg-46)
+      #   * How to remove nth occurrence?
+      #   * Default to removing 1st occurrence from the beginning of the list.
+    end
   end
 end

--- a/spec/hydra/works/services/collection/add_collection_spec.rb
+++ b/spec/hydra/works/services/collection/add_collection_spec.rb
@@ -75,43 +75,52 @@ describe Hydra::Works::AddCollectionToCollection do
       end
     end
 
-    context 'with unacceptable child collections' do
-      let(:generic_work1)    { Hydra::Works::GenericWork::Base.new }
-      let(:generic_file1)    { Hydra::Works::GenericFile::Base.new }
-      let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-      let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-      let(:pcdm_file1)       { Hydra::PCDM::File.new }
-      let(:non_PCDM_object)  { "I'm not a PCDM object" }
-      let(:af_base_object)   { ActiveFedora::Base.new }
-
-      let(:error_message) { 'child_collection must be a hydra-works collection' }
-
-      it 'should NOT aggregate Hydra::Works::GenericWork in collections aggregation' do
-        expect{ Hydra::Works::AddCollectionToCollection.call( subject, generic_work1 ) }.to raise_error(ArgumentError,error_message)
+    context 'with unacceptable inputs' do
+      before(:all) do
+        @works_collection101  = Hydra::Works::Collection.new
+        @generic_work101      = Hydra::Works::GenericWork::Base.new
+        @generic_file101      = Hydra::Works::GenericFile::Base.new
+        @pcdm_collection101   = Hydra::PCDM::Collection.new
+        @pcdm_object101       = Hydra::PCDM::Object.new
+        @pcdm_file101         = Hydra::PCDM::File.new
+        @non_PCDM_object      = "I'm not a PCDM object"
+        @af_base_object       = ActiveFedora::Base.new
       end
 
-      it 'should NOT aggregate Hydra::Works::GenericFile in collections aggregation' do
-        expect{ Hydra::Works::AddCollectionToCollection.call( subject, generic_file1 ) }.to raise_error(ArgumentError,error_message)
-      end
+      context 'that are unacceptable child collections' do
 
-      it 'should NOT aggregate Hydra::PCDM::Collections in collections aggregation' do
-        expect{ Hydra::Works::AddCollectionToCollection.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        let(:error_type1)    { ArgumentError }
+        let(:error_message1) { /Hydra::Works::Generic(Work|File)::Base with ID:  was expected to works_collection\?, but it was false/ }
+        let(:error_type2)    { NoMethodError }
+        let(:error_message2) { /undefined method `works_collection\?' for .*/ }
 
-      it 'should NOT aggregate Hydra::PCDM::Objects in collections aggregation' do
-        expect{ Hydra::Works::AddCollectionToCollection.call( subject, pcdm_object1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::GenericWork in collections aggregation' do
+          expect{ Hydra::Works::AddCollectionToCollection.call( @works_collection101, @generic_work101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in collections aggregation' do
-        expect{ Hydra::Works::AddCollectionToCollection.call( subject, pcdm_file1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::GenericFile in collections aggregation' do
+          expect{ Hydra::Works::AddCollectionToCollection.call( @works_collection101, @generic_file101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate non-PCDM objects in collections aggregation' do
-        expect{ Hydra::Works::AddCollectionToCollection.call( subject, non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::PCDM::Collections in collections aggregation' do
+          expect{ Hydra::Works::AddCollectionToCollection.call( @works_collection101, @pcdm_collection101 ) }.to raise_error(error_type2,error_message2)
+        end
 
-      it 'should NOT aggregate AF::Base objects in collections aggregation' do
-        expect{ Hydra::Works::AddCollectionToCollection.call( subject, af_base_object ) }.to raise_error(ArgumentError,error_message)
+        it 'should NOT aggregate Hydra::PCDM::Objects in collections aggregation' do
+          expect{ Hydra::Works::AddCollectionToCollection.call( @works_collection101, @pcdm_object101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate Hydra::PCDM::Files in collections aggregation' do
+          expect{ Hydra::Works::AddCollectionToCollection.call( @works_collection101, @pcdm_file101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate non-PCDM objects in collections aggregation' do
+          expect{ Hydra::Works::AddCollectionToCollection.call( @works_collection101, @non_PCDM_object ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate AF::Base objects in collections aggregation' do
+          expect{ Hydra::Works::AddCollectionToCollection.call( @works_collection101, @af_base_object ) }.to raise_error(error_type2,error_message2)
+        end
       end
     end
   end

--- a/spec/hydra/works/services/collection/add_generic_work_spec.rb
+++ b/spec/hydra/works/services/collection/add_generic_work_spec.rb
@@ -66,43 +66,52 @@ describe Hydra::Works::AddGenericWorkToCollection do
       end
     end
 
-    context 'with unacceptable child generic_works' do
-      let(:collection1)      { Hydra::Works::Collection.new }
-      let(:generic_file1)    { Hydra::Works::GenericFile::Base.new }
-      let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-      let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-      let(:pcdm_file1)       { Hydra::PCDM::File.new }
-      let(:non_PCDM_object)  { "I'm not a PCDM object" }
-      let(:af_base_object)   { ActiveFedora::Base.new }
-
-      let(:error_message) { 'child_generic_work must be a hydra-works generic work' }
-
-      it 'should NOT aggregate Hydra::Works::Collection in hydra works collections aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToCollection.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
+    context 'with unacceptable inputs' do
+      before(:all) do
+        @works_collection101  = Hydra::Works::Collection.new
+        @works_collection102  = Hydra::Works::Collection.new
+        @generic_file101      = Hydra::Works::GenericFile::Base.new
+        @pcdm_collection101   = Hydra::PCDM::Collection.new
+        @pcdm_object101       = Hydra::PCDM::Object.new
+        @pcdm_file101         = Hydra::PCDM::File.new
+        @non_PCDM_object      = "I'm not a PCDM object"
+        @af_base_object       = ActiveFedora::Base.new
       end
 
-      it 'should NOT aggregate Hydra::Works::GenericFile in hydra works collections aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToCollection.call( subject, generic_file1 ) }.to raise_error(ArgumentError,error_message)
-      end
+      context 'that are unacceptable child generic works' do
 
-      it 'should NOT aggregate Hydra::PCDM::Collections in hydra works collections aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToCollection.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        let(:error_type1)    { ArgumentError }
+        let(:error_message1) { /Hydra::Works::(GenericFile::Base|Collection) with ID:  was expected to works_generic_work\?, but it was false/ }
+        let(:error_type2)    { NoMethodError }
+        let(:error_message2) { /undefined method `works_generic_work\?' for .*/ }
 
-      it 'should NOT aggregate Hydra::PCDM::Objects in hydra works collections aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToCollection.call( subject, pcdm_object1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::Collection in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToCollection.call( @works_collection102, @works_collection101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in hydra works collections aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToCollection.call( subject, pcdm_file1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::GenericFile in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToCollection.call( @works_collection102, @generic_file101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate non-PCDM objects in hydra works collections aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToCollection.call( subject, non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::PCDM::Collections in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToCollection.call( @works_collection102, @pcdm_collection101 ) }.to raise_error(error_type2,error_message2)
+        end
 
-      it 'should NOT aggregate AF::Base objects in hydra works collections aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToCollection.call( subject, af_base_object ) }.to raise_error(ArgumentError,error_message)
+        it 'should NOT aggregate Hydra::PCDM::Objects in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToCollection.call( @works_collection102, @pcdm_object101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate Hydra::PCDM::Files in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToCollection.call( @works_collection102, @pcdm_file101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate non-PCDM objects in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToCollection.call( @works_collection102, @non_PCDM_object ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate AF::Base objects in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToCollection.call( @works_collection102, @af_base_object ) }.to raise_error(error_type2,error_message2)
+        end
       end
     end
   end

--- a/spec/hydra/works/services/collection/remove_collection_spec.rb
+++ b/spec/hydra/works/services/collection/remove_collection_spec.rb
@@ -46,45 +46,4 @@ describe Hydra::Works::RemoveCollectionFromCollection do
       end
     end
   end
-
-  context 'with unacceptable collections' do
-    let(:generic_work1)    { Hydra::Works::GenericWork::Base.new }
-    let(:generic_file1)    { Hydra::Works::GenericFile::Base.new }
-    let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-    let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-    let(:pcdm_file1)       { Hydra::PCDM::File.new }
-    let(:non_PCDM_object)  { "I'm not a PCDM object" }
-    let(:af_base_object)   { ActiveFedora::Base.new }
-
-    let(:error_type)    { ArgumentError }
-    let(:error_message) { 'child_collection must be a hydra-works collection' }
-
-    it 'should NOT remove Hydra::Works::GenericWork from collections aggregation' do
-      expect{ Hydra::Works::RemoveCollectionFromCollection.call( subject, generic_work1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::Works::GenericFile from collections aggregation' do
-      expect{ Hydra::Works::RemoveCollectionFromCollection.call( subject, generic_file1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Collections from collections aggregation' do
-      expect{ Hydra::Works::RemoveCollectionFromCollection.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Objects from collections aggregation' do
-      expect{ Hydra::Works::RemoveCollectionFromCollection.call( subject, pcdm_object1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Files from collections aggregation' do
-      expect{ Hydra::Works::RemoveCollectionFromCollection.call( subject, pcdm_file1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove non-PCDM objects from collections aggregation' do
-      expect{ Hydra::Works::RemoveCollectionFromCollection.call( subject, non_PCDM_object ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove AF::Base objects from collections aggregation' do
-      expect{ Hydra::Works::RemoveCollectionFromCollection.call( subject, af_base_object ) }.to raise_error(error_type,error_message)
-    end
-  end
 end

--- a/spec/hydra/works/services/collection/remove_generic_work_spec.rb
+++ b/spec/hydra/works/services/collection/remove_generic_work_spec.rb
@@ -46,45 +46,4 @@ describe Hydra::Works::RemoveGenericWorkFromCollection do
       end
     end
   end
-
-  context 'with unacceptable generic works' do
-    let(:collection1)    { Hydra::Works::Collection.new }
-    let(:generic_file1)    { Hydra::Works::GenericFile::Base.new }
-    let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-    let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-    let(:pcdm_file1)       { Hydra::PCDM::File.new }
-    let(:non_PCDM_object)  { "I'm not a PCDM object" }
-    let(:af_base_object)   { ActiveFedora::Base.new }
-
-    let(:error_type)    { ArgumentError }
-    let(:error_message) { 'child_generic_work must be a hydra-works generic work' }
-
-    it 'should NOT remove Hydra::Works::Collection from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromCollection.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::Works::GenericFile from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromCollection.call( subject, generic_file1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Collections from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromCollection.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Objects from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromCollection.call( subject, pcdm_object1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Files from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromCollection.call( subject, pcdm_file1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove non-PCDM objects from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromCollection.call( subject, non_PCDM_object ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove AF::Base objects from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromCollection.call( subject, af_base_object ) }.to raise_error(error_type,error_message)
-    end
-  end
 end

--- a/spec/hydra/works/services/generic_file/add_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_generic_file_spec.rb
@@ -83,43 +83,54 @@ describe Hydra::Works::AddGenericFileToGenericFile do
       end
     end
 
-    context 'with unacceptable child generic_files' do
-      let(:collection1)      { Hydra::Works::Collection.new }
-      let(:generic_work1)    { Hydra::Works::GenericWork::Base.new }
-      let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-      let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-      let(:pcdm_file1)       { Hydra::PCDM::File.new }
-      let(:non_PCDM_object)  { "I'm not a PCDM object" }
-      let(:af_base_object)   { ActiveFedora::Base.new }
+    context 'with unacceptable inputs' do
+      before(:all) do
+        @generic_file102      = Hydra::Works::GenericFile::Base.new
 
-      let(:error_message) { 'child_generic_file must be a hydra-works generic file' }
-
-      it 'should NOT aggregate Hydra::Works::Collection in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericFile.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
+        @works_collection101  = Hydra::Works::Collection.new
+        @generic_work101      = Hydra::Works::GenericWork::Base.new
+        @generic_file101      = Hydra::Works::GenericFile::Base.new
+        @pcdm_collection101   = Hydra::PCDM::Collection.new
+        @pcdm_object101       = Hydra::PCDM::Object.new
+        @pcdm_file101         = Hydra::PCDM::File.new
+        @non_PCDM_object      = "I'm not a PCDM object"
+        @af_base_object       = ActiveFedora::Base.new
       end
 
-      it 'should NOT aggregate Hydra::Works::GenericWork in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericFile.call( subject, generic_work1 ) }.to raise_error(ArgumentError,error_message)
-      end
+      context 'that are unacceptable child generic files' do
 
-      it 'should NOT aggregate Hydra::PCDM::Collections in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericFile.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        let(:error_type1)    { ArgumentError }
+        let(:error_message1) { /Hydra::Works::(GenericWork::Base|Collection) with ID:  was expected to works_generic_file\?, but it was false/ }
+        let(:error_type2)    { NoMethodError }
+        let(:error_message2) { /undefined method `works_generic_file\?' for .*/ }
 
-      it 'should NOT aggregate Hydra::PCDM::Objects in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericFile.call( subject, pcdm_object1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::Collection in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericFile.call( @generic_file102, @works_collection101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericFile.call( subject, pcdm_file1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::GenericWork in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericWork.call( @generic_file102, @generic_work101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate non-PCDM objects in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericFile.call( subject, non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::PCDM::Collections in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericFile.call( @generic_file102, @pcdm_collection101 ) }.to raise_error(error_type2,error_message2)
+        end
 
-      it 'should NOT aggregate AF::Base objects in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericFile.call( subject, af_base_object ) }.to raise_error(ArgumentError,error_message)
+        it 'should NOT aggregate Hydra::PCDM::Objects in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericFile.call( @generic_file102, @pcdm_object101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate Hydra::PCDM::Files in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericFile.call( @generic_file102, @pcdm_file101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate non-PCDM objects in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericFile.call( @generic_file102, @non_PCDM_object ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate AF::Base objects in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericFile.call( @generic_file102, @af_base_object ) }.to raise_error(error_type2,error_message2)
+        end
       end
     end
   end

--- a/spec/hydra/works/services/generic_file/remove_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/remove_generic_file_spec.rb
@@ -37,45 +37,4 @@ describe Hydra::Works::RemoveGenericFileFromGenericFile do
       end
     end
   end
-
-  context 'with unacceptable generic files' do
-    let(:collection1)    { Hydra::Works::Collection.new }
-    let(:generic_work1)    { Hydra::Works::GenericWork::Base.new }
-    let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-    let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-    let(:pcdm_file1)       { Hydra::PCDM::File.new }
-    let(:non_PCDM_object)  { "I'm not a PCDM object" }
-    let(:af_base_object)   { ActiveFedora::Base.new }
-
-    let(:error_type)    { ArgumentError }
-    let(:error_message) { 'child_generic_file must be a hydra-works generic file' }
-
-    it 'should NOT remove Hydra::Works::Collection from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::Works::GenericWork from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, generic_work1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Collections from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Objects from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, pcdm_object1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Files from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, pcdm_file1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove non-PCDM objects from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, non_PCDM_object ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove AF::Base objects from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericFile.call( subject, af_base_object ) }.to raise_error(error_type,error_message)
-    end
-  end
 end

--- a/spec/hydra/works/services/generic_work/add_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_work/add_generic_file_spec.rb
@@ -66,43 +66,54 @@ describe Hydra::Works::AddGenericFileToGenericWork do
       end
     end
 
-    context 'with unacceptable child generic_files' do
-      let(:collection1)      { Hydra::Works::Collection.new }
-      let(:generic_work1)    { Hydra::Works::GenericWork::Base.new }
-      let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-      let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-      let(:pcdm_file1)       { Hydra::PCDM::File.new }
-      let(:non_PCDM_object)  { "I'm not a PCDM object" }
-      let(:af_base_object)   { ActiveFedora::Base.new }
+    context 'with unacceptable inputs' do
+      before(:all) do
+        @generic_work102      = Hydra::Works::GenericWork::Base.new
 
-      let(:error_message) { 'child_generic_file must be a hydra-works generic file' }
-
-      it 'should NOT aggregate Hydra::Works::Collection in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericWork.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
+        @works_collection101  = Hydra::Works::Collection.new
+        @generic_work101      = Hydra::Works::GenericWork::Base.new
+        @generic_file101      = Hydra::Works::GenericFile::Base.new
+        @pcdm_collection101   = Hydra::PCDM::Collection.new
+        @pcdm_object101       = Hydra::PCDM::Object.new
+        @pcdm_file101         = Hydra::PCDM::File.new
+        @non_PCDM_object      = "I'm not a PCDM object"
+        @af_base_object       = ActiveFedora::Base.new
       end
 
-      it 'should NOT aggregate Hydra::Works::GenericWork in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericWork.call( subject, generic_work1 ) }.to raise_error(ArgumentError,error_message)
-      end
+      context 'that are unacceptable child generic files' do
 
-      it 'should NOT aggregate Hydra::PCDM::Collections in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericWork.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        let(:error_type1)    { ArgumentError }
+        let(:error_message1) { /Hydra::Works::(GenericWork::Base|Collection) with ID:  was expected to works_generic_file\?, but it was false/ }
+        let(:error_type2)    { NoMethodError }
+        let(:error_message2) { /undefined method `works_generic_file\?' for .*/ }
 
-      it 'should NOT aggregate Hydra::PCDM::Objects in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericWork.call( subject, pcdm_object1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::Collection in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericWork.call( @generic_work102, @works_collection101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericWork.call( subject, pcdm_file1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::GenericWork in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericWork.call( @generic_work102, @generic_work101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate non-PCDM objects in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericWork.call( subject, non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::PCDM::Collections in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericWork.call( @generic_work102, @pcdm_collection101 ) }.to raise_error(error_type2,error_message2)
+        end
 
-      it 'should NOT aggregate AF::Base objects in generic files aggregation' do
-        expect{ Hydra::Works::AddGenericFileToGenericWork.call( subject, af_base_object ) }.to raise_error(ArgumentError,error_message)
+        it 'should NOT aggregate Hydra::PCDM::Objects in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericWork.call( @generic_work102, @pcdm_object101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate Hydra::PCDM::Files in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericWork.call( @generic_work102, @pcdm_file101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate non-PCDM objects in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericWork.call( @generic_work102, @non_PCDM_object ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate AF::Base objects in generic files aggregation' do
+          expect{ Hydra::Works::AddGenericFileToGenericWork.call( @generic_work102, @af_base_object ) }.to raise_error(error_type2,error_message2)
+        end
       end
     end
   end

--- a/spec/hydra/works/services/generic_work/add_generic_work_spec.rb
+++ b/spec/hydra/works/services/generic_work/add_generic_work_spec.rb
@@ -67,43 +67,53 @@ describe Hydra::Works::AddGenericWorkToGenericWork do
       end
     end
 
-    context 'with unacceptable child generic_works' do
-      let(:collection1)      { Hydra::Works::Collection.new }
-      let(:generic_file1)    { Hydra::Works::GenericFile::Base.new }
-      let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-      let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-      let(:pcdm_file1)       { Hydra::PCDM::File.new }
-      let(:non_PCDM_object)  { "I'm not a PCDM object" }
-      let(:af_base_object)   { ActiveFedora::Base.new }
+    context 'with unacceptable inputs' do
+      before(:all) do
+        @generic_work102      = Hydra::Works::GenericWork::Base.new
 
-      let(:error_message) { 'child_generic_work must be a hydra-works generic work' }
-
-      it 'should NOT aggregate Hydra::Works::Collection in generic works aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToGenericWork.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
+        @works_collection101  = Hydra::Works::Collection.new
+        @generic_file101      = Hydra::Works::GenericFile::Base.new
+        @pcdm_collection101   = Hydra::PCDM::Collection.new
+        @pcdm_object101       = Hydra::PCDM::Object.new
+        @pcdm_file101         = Hydra::PCDM::File.new
+        @non_PCDM_object      = "I'm not a PCDM object"
+        @af_base_object       = ActiveFedora::Base.new
       end
 
-      it 'should NOT aggregate Hydra::Works::GenericFile in generic works aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToGenericWork.call( subject, generic_file1 ) }.to raise_error(ArgumentError,error_message)
-      end
+      context 'that are unacceptable child generic works' do
 
-      it 'should NOT aggregate Hydra::PCDM::Collections in generic works aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToGenericWork.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        let(:error_type1)    { ArgumentError }
+        let(:error_message1) { /Hydra::Works::(GenericFile::Base|Collection) with ID:  was expected to works_generic_work\?, but it was false/ }
+        let(:error_type2)    { NoMethodError }
+        let(:error_message2) { /undefined method `works_generic_work\?' for .*/ }
 
-      it 'should NOT aggregate Hydra::PCDM::Objects in generic works aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToGenericWork.call( subject, pcdm_object1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::Collection in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToGenericWork.call( @generic_work102, @works_collection101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in generic works aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToGenericWork.call( subject, pcdm_file1 ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::Works::GenericFile in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToGenericWork.call( @generic_work102, @generic_file101 ) }.to raise_error(error_type1,error_message1)
+        end
 
-      it 'should NOT aggregate non-PCDM objects in generic works aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToGenericWork.call( subject, non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
-      end
+        it 'should NOT aggregate Hydra::PCDM::Collections in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToGenericWork.call( @generic_work102, @pcdm_collection101 ) }.to raise_error(error_type2,error_message2)
+        end
 
-      it 'should NOT aggregate AF::Base objects in generic works aggregation' do
-        expect{ Hydra::Works::AddGenericWorkToGenericWork.call( subject, af_base_object ) }.to raise_error(ArgumentError,error_message)
+        it 'should NOT aggregate Hydra::PCDM::Objects in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToGenericWork.call( @generic_work102, @pcdm_object101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate Hydra::PCDM::Files in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToGenericWork.call( @generic_work102, @pcdm_file101 ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate non-PCDM objects in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToGenericWork.call( @generic_work102, @non_PCDM_object ) }.to raise_error(error_type2,error_message2)
+        end
+
+        it 'should NOT aggregate AF::Base objects in generic works aggregation' do
+          expect{ Hydra::Works::AddGenericWorkToGenericWork.call( @generic_work102, @af_base_object ) }.to raise_error(error_type2,error_message2)
+        end
       end
     end
   end

--- a/spec/hydra/works/services/generic_work/remove_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_work/remove_generic_file_spec.rb
@@ -45,45 +45,4 @@ describe Hydra::Works::RemoveGenericFileFromGenericWork do
       end
     end
   end
-
-  context 'with unacceptable generic files' do
-    let(:collection1)    { Hydra::Works::Collection.new }
-    let(:generic_work1)    { Hydra::Works::GenericWork::Base.new }
-    let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-    let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-    let(:pcdm_file1)       { Hydra::PCDM::File.new }
-    let(:non_PCDM_object)  { "I'm not a PCDM object" }
-    let(:af_base_object)   { ActiveFedora::Base.new }
-
-    let(:error_type)    { ArgumentError }
-    let(:error_message) { 'child_generic_file must be a hydra-works generic file' }
-
-    it 'should NOT remove Hydra::Works::Collection from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::Works::GenericWork from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, generic_work1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Collections from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Objects from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, pcdm_object1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Files from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, pcdm_file1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove non-PCDM objects from generic_files aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, non_PCDM_object ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove AF::Base objects from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericFileFromGenericWork.call( subject, af_base_object ) }.to raise_error(error_type,error_message)
-    end
-  end
 end

--- a/spec/hydra/works/services/generic_work/remove_generic_work_spec.rb
+++ b/spec/hydra/works/services/generic_work/remove_generic_work_spec.rb
@@ -46,45 +46,4 @@ describe Hydra::Works::RemoveGenericWorkFromGenericWork do
       end
     end
   end
-
-  context 'with unacceptable generic works' do
-    let(:collection1)    { Hydra::Works::Collection.new }
-    let(:generic_file1)    { Hydra::Works::GenericFile::Base.new }
-    let(:pcdm_collection1) { Hydra::PCDM::Collection.new }
-    let(:pcdm_object1)     { Hydra::PCDM::Object.new }
-    let(:pcdm_file1)       { Hydra::PCDM::File.new }
-    let(:non_PCDM_object)  { "I'm not a PCDM object" }
-    let(:af_base_object)   { ActiveFedora::Base.new }
-
-    let(:error_type)    { ArgumentError }
-    let(:error_message) { 'child_generic_work must be a hydra-works generic work' }
-
-    it 'should NOT remove Hydra::Works::Collection from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::Works::GenericFile from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, generic_file1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Collections from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, pcdm_collection1 ) }.to raise_error(ArgumentError,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Objects from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, pcdm_object1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove Hydra::PCDM::Files from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, pcdm_file1 ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove non-PCDM objects from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, non_PCDM_object ) }.to raise_error(error_type,error_message)
-    end
-
-    it 'should NOT remove AF::Base objects from generic_works aggregation' do
-      expect{ Hydra::Works::RemoveGenericWorkFromGenericWork.call( subject, af_base_object ) }.to raise_error(error_type,error_message)
-    end
-  end
 end


### PR DESCRIPTION
Change Log:
* use filter associations
* rework to use parent/child consistently
* add indexers for collections, generic works, generic files
* deprecate atomic service objects
* minimal updates to tests (mostly error messages, removal of unacceptable parent tests, unnecessary save-reload)