### PR TITLE
deprecate methods in works.rb for issue 164

### DIFF
--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -64,20 +64,20 @@ module Hydra
     autoload :GenerateThumbnail,                   'hydra/works/services/generic_file/generate/thumbnail'
     autoload :PersistDerivative,                   'hydra/works/services/generic_file/persist_derivative'
 
-    # model validations
+    # model validations - these have been deprecated
     def self.collection? collection
-      return false unless collection.respond_to? :type
-      collection.type.include? WorksVocabularies::WorksTerms.Collection
+      warn "[DEPRECATION] `collection? collection` is deprecated.  Please use `works_collection?` instead.  This has a target date for removal of 07-31-2015"
+      collection.works_collection?
     end
 
     def self.generic_work? generic_work
-      return false unless generic_work.respond_to? :type
-      generic_work.type.include? WorksVocabularies::WorksTerms.GenericWork
+      warn "[DEPRECATION] `generic_work? generic_work` is deprecated.  Please use `works_generic_work?` instead.  This has a target date for removal of 07-31-2015"
+      generic_work.works_generic_work?
     end
 
     def self.generic_file? generic_file
-      return false unless generic_file.respond_to? :type
-      generic_file.type.include? WorksVocabularies::WorksTerms.GenericFile
+      warn "[DEPRECATION] `generic_file? generic_file` is deprecated.  Please use `works_generic_file?` instead.  This has a target date for removal of 07-31-2015"
+      generic_file.works_generic_file?
     end
 
   end

--- a/spec/hydra/works_spec.rb
+++ b/spec/hydra/works_spec.rb
@@ -12,81 +12,81 @@ describe Hydra::Works do
 
   describe 'Validations' do
 
-    describe "#collection?" do
+    describe "#works_collection?" do
       it "should return true for a works collection" do
-        expect( Hydra::Works.collection? works_coll ).to be true
+        expect( works_coll.works_collection? ).to be true
       end
 
       it "should return false for a works generic work" do
-        expect( Hydra::Works.collection? works_gwork ).to be false
+        expect( works_gwork.works_collection? ).to be false
       end
 
       it "should return false for a works generic file" do
-        expect( Hydra::Works.collection? works_gfile ).to be false
+        expect( works_gfile.works_collection? ).to be false
       end
 
-      it "should return false for a pcdm collection" do
-        expect( Hydra::Works.collection? pcdm_coll ).to be false
+      it "should return that method is not available for pcdm a collection" do
+        expect(pcdm_coll).not_to respond_to(:works_collection?)
       end
 
-      it "should return false for a pcdm object" do
-        expect( Hydra::Works.collection? pcdm_obj ).to be false
+      it "should return that method is not available for a pcdm object" do
+        expect(pcdm_obj).not_to respond_to(:works_collection?)
       end
 
-      it "should return false for a pcdm file" do
-        expect( Hydra::Works.collection? pcdm_file ).to be false
+      it "should return that method is not available for a pcdm file" do
+        expect(pcdm_file).not_to respond_to(:works_collection?)
       end
     end
 
-    describe "#generic_work?" do
+    describe "#works_generic_work?" do
       it "should return false for a works collection" do
-        expect( Hydra::Works.generic_work? works_coll ).to be false
+        expect( works_coll.works_generic_work? ).to be false
       end
 
       it "should return true for a works generic work" do
-        expect( Hydra::Works.generic_work? works_gwork ).to be true
+        expect( works_gwork.works_generic_work? ).to be true
       end
 
       it "should return false for a works generic file" do
-        expect( Hydra::Works.generic_work? works_gfile ).to be false
+        expect( works_gfile.works_generic_work? ).to be false
       end
 
-      it "should return false for a pcdm collection" do
-        expect( Hydra::Works.generic_work? pcdm_coll ).to be false
+      it "should return that method is not available for a pcdm collection" do
+        expect(pcdm_coll).not_to respond_to(:works_generic_work?)
       end
 
-      it "should return false for a pcdm object" do
-        expect( Hydra::Works.generic_work? pcdm_obj ).to be false
+      it "should return that method is not available for a pcdm object" do
+        expect(pcdm_obj).not_to respond_to(:works_generic_work?)
       end
 
-      it "should return false for a pcdm file" do
-        expect( Hydra::Works.generic_work? pcdm_file ).to be false
+      it "should return that method is not available for a pcdm file" do
+        expect(pcdm_file).not_to respond_to(:works_generic_work?)
       end
     end
 
-    describe "#generic_file?" do
+    describe "#works_generic_file?" do
       it "should return false for a works collection" do
-        expect( Hydra::Works.generic_file? works_coll ).to be false
+        expect( works_coll.works_generic_file? ).to be false
       end
 
       it "should return false for a works generic work" do
-        expect( Hydra::Works.generic_file? works_gwork ).to be false
+        expect( works_gwork.works_generic_file? ).to be false
       end
 
       it "should return true for a works generic file" do
-        expect( Hydra::Works.generic_file? works_gfile ).to be true
+        expect( works_gfile.works_generic_file? ).to be true
       end
 
-      it "should return false for a pcdm collection" do
-        expect( Hydra::Works.generic_file? pcdm_coll ).to be false
+      it "should return that method is not available for a pcdm collection" do
+        expect(pcdm_coll).not_to respond_to(:works_generic_file?)
       end
 
-      it "should return false for a pcdm object" do
-        expect( Hydra::Works.generic_file? pcdm_obj ).to be false
+      it "should return that method is not available for a pcdm object" do
+        expect(pcdm_obj).not_to respond_to(:works_generic_file?)
       end
 
-      it "should return false for a pcdm file" do
-        expect( Hydra::Works.generic_file? pcdm_file ).to be false
+      it "should return that method is not available for a pcdm file" do
+        expect(pcdm_file).not_to respond_to(:works_generic_file?)
       end
     end
   end


### PR DESCRIPTION
deprecate validations in works.rb and use works_generic_file? works_generic_work? and works_collection? instead.

This is to address this issue:  https://github.com/projecthydra-labs/hydra-works/issues/164

If this looks good, I can fix spec/hydra/works_spec.rb to use the new methods and not the deprecated methods.  Should I do that as part of this issue?

-Jose