### PR TITLE
Changing RDF Vocabulary namespace to projecthydra.org

### DIFF
--- a/lib/hydra/works/vocab/works_terms.rb
+++ b/lib/hydra/works/vocab/works_terms.rb
@@ -1,6 +1,6 @@
 require 'rdf'
 module WorksVocabularies
-  class WorksTerms < RDF::Vocabulary("http://hydra.org/works/models#")
+  class WorksTerms < RDF::Vocabulary("http://projecthydra.org/works/models#")
 
     # Class definitions
     term :Collection


### PR DESCRIPTION
We really shouldn't use "hydra.org", since that's something completely different.