### PR TITLE
Use Rubocop to ensure consistently styled code.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,49 @@
+require: rubocop-rspec
+
+AllCops:
+  RunRailsCops: true
+  DisplayCopNames: true
+  Include:
+    - '**/Rakefile'
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - lib/hydra/works/services/generic_file/add_file_to_generic_file.rb
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - lib/hydra/works/services/generic_file/add_file_to_generic_file.rb
+
+Metrics/MethodLength:
+  Exclude:
+    - lib/hydra/works/services/generic_file/add_file_to_generic_file.rb
+    - lib/hydra/works/models/concerns/generic_file/virus_check.rb
+
+Metrics/AbcSize:
+  Exclude:
+    - lib/hydra/works/services/generic_file/add_file_to_generic_file.rb
+    - lib/hydra/works/models/concerns/generic_file/mime_types.rb
+    - lib/hydra/works/models/concerns/generic_file/virus_check.rb
+
+Style/CollectionMethods:
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+RSpec/FilePath:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,9 @@ gemspec
 
 gem 'slop', '~> 3.6' # For byebug
 
-unless ENV['CI']
-  gem 'pry'
-  gem 'pry-byebug'
-  gem 'byebug'
+group :development, :test do
+  gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
+  gem 'pry' unless ENV['CI']
+  gem 'pry-byebug' unless ENV['CI']
 end

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # Hydra::Works
+
+[![Version](https://badge.fury.io/rb/hydra-works.png)](http://badge.fury.io/rb/hydra-works)
 [![Build Status](https://travis-ci.org/projecthydra-labs/hydra-works.svg?branch=master)](https://travis-ci.org/projecthydra-labs/hydra-works)
 [![Coverage Status](https://coveralls.io/repos/projecthydra-labs/hydra-works/badge.svg?branch=master)](https://coveralls.io/r/projecthydra-labs/hydra-works?branch=master)
+[![Code Climate](https://codeclimate.com/github/projecthydra-labs/hydra-works/badges/gpa.svg)](https://codeclimate.com/github/projecthydra-labs/hydra-works)
+[![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
+[![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
+[![API Docs](http://img.shields.io/badge/API-docs-blue.svg)](http://rubydoc.info/gems/hydra-works)
+[![Stories in Ready](https://badge.waffle.io/projecthydra-labs/hydra-works.png?source=projecthydra-labs%2Fhydra-works&label=ready&title=Ready)](https://waffle.io/projecthydra-labs/hydra-works?source=projecthydra-labs%2Fhydra-works)
 
-The Hydra::Works gem provides a set of [Portland Common Data Model](https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model)-compliant models and associated behaviors around the broad concept of multi-file "works", the need for which was expressed by a variety of [community use cases](https://github.com/projecthydra-labs/hydra-works/tree/master/use-cases). The Hydra::Works domain model includes:
+The Hydra::Works gem provides a set of [Portland Common Data Model](https://github.com/duraspace/pcdm/wiki)-compliant ActiveFedora models and associated behaviors around the broad concept of multi-file "works", the need for which was expressed by a variety of [community use cases](https://github.com/projecthydra-labs/hydra-works/tree/master/use-cases). The Hydra::Works domain model includes:
 
- * **GenericFile**: a *pcdm:Object* that encapsulates one or more directly related *pcdm:File*s, such as a PDF document, its derivatives, and extracted full-text
- * **GenericWork**: a *pcdm:Object* that holds zero or more **GenericFile**s and zero or more **GenericWork**s
- * **Collection**: a *pcdm:Collection* that indirectly contains zero or more **GenericWork**s and zero or more **Collection**s
+ * **GenericFile**: a *Hydra::PCDM::Object* that encapsulates one or more directly related *Hydra::PCDM::File*s, such as a PDF document, its derivatives, and extracted full-text
+ * **GenericWork**: a *Hydra::PCDM::Object* that holds zero or more **GenericFile**s and zero or more **GenericWork**s
+ * **Collection**: a *Hydra::PCDM::Collection* that indirectly contains zero or more **GenericWork**s and zero or more **Collection**s
 
 View [a diagram of the domain model](https://docs.google.com/drawings/d/1-NkkRPpGpZGoTimEpYTaGM1uUPRaT0SamuWDITvtG_8/edit).
 
@@ -14,10 +21,7 @@ View [a diagram of the domain model](https://docs.google.com/drawings/d/1-NkkRPp
 
 Add these lines to your application's Gemfile:
 
-    # hydra-pcdm requires an unreleased version of ActiveFedora
-    gem 'active-fedora', github: 'projecthydra/active_fedora'
-    gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm'
-    gem 'hydra-works', github: 'projecthydra-labs/hydra-works'
+    gem 'hydra-works', '~> 0.1'
 
 And then execute:
 
@@ -73,14 +77,13 @@ class BookFiles < ActiveFedora::Base
 end
 ```
 
-
 ## Access controls
 
 We are using [Web ACL](http://www.w3.org/wiki/WebAccessControl) as implemented by [hydra-access-controls](https://github.com/projecthydra/hydra-head/tree/master/hydra-access-controls).
 
 ## How to contribute
 
-If you'd like to contribute to this effort, please check out the [Contributing Guide](CONTRIBUTING.md)
+If you'd like to contribute to this effort, please check out the [contributing guidelines](CONTRIBUTING.md)
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,31 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 require 'jettywrapper'
 require 'rspec/core'
 require 'rspec/core/rake_task'
 require 'engine_cart/rake_task'
+require 'rubocop/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
-Jettywrapper.hydra_jetty_version = "master"
+desc 'Run style checker'
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.requires << 'rubocop-rspec'
+  task.fail_on_error = true
+end
+
+desc 'Run test suite and style checker'
+task :spec do
+  Rake::Task['rubocop'].invoke
+  RSpec::Core::RakeTask.new(:spec)
+end
 
 desc 'Spin up hydra-jetty and run specs'
 task ci: ['jetty:clean'] do
   puts 'running continuous integration'
   jetty_params = Jettywrapper.load_config
-  jetty_params[:startup_wait]= 90
+  jetty_params[:startup_wait] = 90
   error = Jettywrapper.wrap(jetty_params) do
     Rake::Task['spec'].invoke
   end
-  raise "test failures: #{error}" if error
+  fail "test failures: #{error}" if error
 end
 
 task default: :ci
-
-

--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -15,7 +15,7 @@ module Hydra
     autoload :GenericWork,            'hydra/works/models/generic_work'
     autoload :GenericFile,            'hydra/works/models/generic_file'
 
-    #behaviors
+    # behaviors
     autoload :CollectionBehavior,     'hydra/works/models/concerns/collection_behavior'
     autoload :GenericWorkBehavior,    'hydra/works/models/concerns/generic_work_behavior'
     autoload :GenericFileBehavior,    'hydra/works/models/concerns/generic_file_behavior'

--- a/lib/hydra/works/models/concerns/block_child_objects.rb
+++ b/lib/hydra/works/models/concerns/block_child_objects.rb
@@ -1,16 +1,12 @@
 module Hydra::Works
   # Do not allow aggregation of child objects
   module BlockChildObjects
-
-    def child_objects= objects
-      raise StandardError, "method `child_objects=' not allowed for #{self}"
+    def child_objects=(_objects)
+      fail StandardError, "method `child_objects=' not allowed for #{self}"
     end
 
     def child_objects
-      raise StandardError, "method `child_objects' not allowed for #{self}"
+      fail StandardError, "method `child_objects' not allowed for #{self}"
     end
-
   end
 end
-
-

--- a/lib/hydra/works/models/concerns/collection_behavior.rb
+++ b/lib/hydra/works/models/concerns/collection_behavior.rb
@@ -1,5 +1,4 @@
 module Hydra::Works
-
   # This module provides all of the Behaviors of a Hydra::Works::Collection
   #
   # behavior:
@@ -19,7 +18,7 @@ module Hydra::Works
     include Hydra::PCDM::CollectionBehavior
 
     included do
-      type [RDFVocabularies::PCDMTerms.Collection,WorksVocabularies::WorksTerms.Collection]
+      type [RDFVocabularies::PCDMTerms.Collection, WorksVocabularies::WorksTerms.Collection]
       include Hydra::Works::BlockChildObjects
 
       filters_association :members, as: :child_collections, condition: :works_collection?
@@ -48,6 +47,5 @@ module Hydra::Works
     def parent_collections
       aggregated_by.select { |parent| parent.class.included_modules.include?(Hydra::Works::CollectionBehavior) }
     end
-
   end
 end

--- a/lib/hydra/works/models/concerns/generic_file/contained_files.rb
+++ b/lib/hydra/works/models/concerns/generic_file/contained_files.rb
@@ -7,8 +7,8 @@ module Hydra::Works::GenericFile::ContainedFiles
 
   # TODO: se PCDM vocab class when projecthydra-labs/hydra-pcdm#80 is merged
   included do
-    directly_contains_one :original_file, through: :files, type: ::RDF::URI("http://pcdm.org/use#OriginalFile"), class_name: "Hydra::PCDM::File"
-    directly_contains_one :thumbnail, through: :files, type: ::RDF::URI("http://pcdm.org/use#ThumbnailImage"), class_name: "Hydra::PCDM::File"
-    directly_contains_one :extracted_text, through: :files, type: ::RDF::URI("http://pcdm.org/use#ExtractedText"), class_name: "Hydra::PCDM::File"
+    directly_contains_one :original_file, through: :files, type: ::RDF::URI('http://pcdm.org/use#OriginalFile'), class_name: 'Hydra::PCDM::File'
+    directly_contains_one :thumbnail, through: :files, type: ::RDF::URI('http://pcdm.org/use#ThumbnailImage'), class_name: 'Hydra::PCDM::File'
+    directly_contains_one :extracted_text, through: :files, type: ::RDF::URI('http://pcdm.org/use#ExtractedText'), class_name: 'Hydra::PCDM::File'
   end
 end

--- a/lib/hydra/works/models/concerns/generic_file/derivatives.rb
+++ b/lib/hydra/works/models/concerns/generic_file/derivatives.rb
@@ -1,7 +1,7 @@
 module Hydra::Works::GenericFile
   module Derivatives
     extend ActiveSupport::Concern
-    
+
     included do
       include Hydra::Derivatives
 
@@ -21,8 +21,6 @@ module Hydra::Works::GenericFile
           obj.transform_file :original_file, thumbnail: { format: 'jpg', size: '200x150>' }
         end
       end
-
     end
-
   end
 end

--- a/lib/hydra/works/models/concerns/generic_file/mime_types.rb
+++ b/lib/hydra/works/models/concerns/generic_file/mime_types.rb
@@ -30,13 +30,11 @@ module Hydra::Works::GenericFile
 
     def file_format
       if mime_type.present? && format_label.present?
-        "#{mime_type.split('/').last} (#{format_label.join(", ")})"
+        "#{mime_type.split('/').last} (#{format_label.join(', ')})"
       elsif mime_type.present?
         mime_type.split('/').last
       elsif format_label.present?
         format_label
-      else
-        nil
       end
     end
 

--- a/lib/hydra/works/models/concerns/generic_file/versioned_content.rb
+++ b/lib/hydra/works/models/concerns/generic_file/versioned_content.rb
@@ -1,18 +1,16 @@
 module Hydra::Works::GenericFile
   # Allows a GenericFile to treat the version history of the original_file as the GenericFile's version history
   module VersionedContent
-
     def content_versions
-      self.original_file.versions.all
+      original_file.versions.all
     end
 
     def latest_content_version
-      self.original_file.versions.last
+      original_file.versions.last
     end
 
     def current_content_version_uri
-      self.original_file.versions.last.uri
+      original_file.versions.last.uri
     end
-
   end
 end

--- a/lib/hydra/works/models/concerns/generic_file/virus_check.rb
+++ b/lib/hydra/works/models/concerns/generic_file/virus_check.rb
@@ -1,7 +1,7 @@
 module Hydra::Works::GenericFile
   module VirusCheck
     extend ActiveSupport::Concern
-    
+
     included do
       validate :detect_viruses
     end
@@ -43,6 +43,5 @@ module Hydra::Works::GenericFile
         end
       end
     end
-
   end
 end

--- a/lib/hydra/works/models/concerns/generic_file_behavior.rb
+++ b/lib/hydra/works/models/concerns/generic_file_behavior.rb
@@ -13,7 +13,7 @@ module Hydra::Works
     include Hydra::PCDM::ObjectBehavior
 
     included do
-      type [RDFVocabularies::PCDMTerms.Object,WorksVocabularies::WorksTerms.GenericFile]
+      type [RDFVocabularies::PCDMTerms.Object, WorksVocabularies::WorksTerms.GenericFile]
 
       include Hydra::Works::GenericFile::ContainedFiles
       include Hydra::Works::GenericFile::Derivatives

--- a/lib/hydra/works/models/concerns/generic_work_behavior.rb
+++ b/lib/hydra/works/models/concerns/generic_work_behavior.rb
@@ -17,15 +17,15 @@ module Hydra::Works
     include Hydra::PCDM::ObjectBehavior
 
     included do
-      type [RDFVocabularies::PCDMTerms.Object,WorksVocabularies::WorksTerms.GenericWork]
+      type [RDFVocabularies::PCDMTerms.Object, WorksVocabularies::WorksTerms.GenericWork]
       include Hydra::Works::BlockChildObjects
 
       filters_association :members, as: :child_generic_works, condition: :works_generic_work?
       filters_association :members, as: :generic_files, condition: :works_generic_file?
     end
 
-    def contains= files
-      raise NoMethodError, "works can not directly contain files.  You must add a GenericFile to the work's members and add files to that GenericFile."
+    def contains=(_files)
+      fail NoMethodError, "works can not directly contain files.  You must add a GenericFile to the work's members and add files to that GenericFile."
     end
 
     # @return [Boolean] whether this instance is a Hydra::Works Collection.
@@ -54,6 +54,5 @@ module Hydra::Works
     def parent_collections
       aggregated_by.select { |parent| parent.class.included_modules.include?(Hydra::Works::CollectionBehavior) }
     end
-
   end
 end

--- a/lib/hydra/works/models/generic_file.rb
+++ b/lib/hydra/works/models/generic_file.rb
@@ -1,7 +1,6 @@
 module Hydra::Works
   # Namespace for Modules with functionality specific to GenericFiles
   module GenericFile
-
     extend ActiveSupport::Concern
 
     autoload :Derivatives,            'hydra/works/models/concerns/generic_file/derivatives'
@@ -10,11 +9,9 @@ module Hydra::Works
     autoload :VersionedContent,       'hydra/works/models/concerns/generic_file/versioned_content'
     autoload :VirusCheck,             'hydra/works/models/concerns/generic_file/virus_check'
 
-
     # Base class for creating objects that behave like Hydra::Works::GenericFiles
     class Base < ActiveFedora::Base
       include Hydra::Works::GenericFileBehavior
     end
-
   end
 end

--- a/lib/hydra/works/services/generic_file/add_file_to_generic_file.rb
+++ b/lib/hydra/works/services/generic_file/add_file_to_generic_file.rb
@@ -1,6 +1,5 @@
 module Hydra::Works
   class AddFileToGenericFile
-
     # Adds a file to the generic_file
     # @param [Hydra::PCDM::GenericFile::Base] generic_file the file will be added to
     # @param [IO,File,Rack::Multipart::UploadedFile, #read] object that will be the contents. If file responds to :mime_type, :content_type, :original_name, or :original_filename, those will be called to provide metadata.
@@ -9,10 +8,10 @@ module Hydra::Works
     # @param [Boolean] versioning whether to create new version entries (only applicable if +type+ corresponds to a versionable file)
 
     def self.call(generic_file, file, type, update_existing: true, versioning: true)
-      raise ArgumentError, "supplied object must be a generic file" unless generic_file.works_generic_file?
-      raise ArgumentError, "supplied file must respond to read" unless file.respond_to? :read
+      fail ArgumentError, 'supplied object must be a generic file' unless generic_file.works_generic_file?
+      fail ArgumentError, 'supplied file must respond to read' unless file.respond_to? :read
 
-      # TODO required as a workaround for https://github.com/projecthydra/active_fedora/pull/858
+      # TODO: required as a workaround for https://github.com/projecthydra/active_fedora/pull/858
       generic_file.save unless generic_file.persisted?
 
       updater_class = versioning ? VersioningUpdater : Updater
@@ -38,90 +37,89 @@ module Hydra::Works
 
       private
 
-        def persist
-          if current_file.new_record?
-            # persist current_file and its membership in generic_file.files container
-            generic_file.save
-          else
-            # we updated the content of an existing file, so we need to save the file explicitly
-            current_file.save
-          end
-        end
-
-        def attach_attributes(file) 
-          current_file.content = file
-          current_file.original_name = determine_original_name(file)
-          current_file.mime_type = determine_mime_type(file)
-        end
-
-        # Return mime_type based on methods available to file
-        # @param object for mimetype to be determined. Attempts to use methods: :mime_type, :content_type, and :path.
-        def determine_mime_type(file)
-          if file.respond_to? :mime_type
-            return file.mime_type
-          elsif file.respond_to? :content_type
-            return file.content_type
-          elsif file.respond_to? :path
-            return Hydra::PCDM::GetMimeTypeForFile.call(file.path)
-          else
-            return "application/octet-stream"
-          end
-        end
-
-        # Return original_name based on methods available to file
-        # @param object for original name to be determined. Attempts to use methods: :original_name, :original_filename, and :path.
-        def determine_original_name(file)
-          if file.respond_to? :original_name
-            return file.original_name
-          elsif file.respond_to? :original_filename
-            return file.original_filename
-          elsif file.respond_to? :path
-            return ::File.basename(file.path)
-          else
-            return ""
-          end
-        end
-
-        # @param [Symbol, RDF::URI] the type of association or filter to use
-        # @param [true, false] update_existing when true, try to retrieve existing element before building one
-        def find_or_create_file(type, update_existing)
-          if type.instance_of? Symbol
-            association = generic_file.association(type)
-            raise ArgumentError, "you're attempting to add a file to a generic_file using '#{type}' association but the generic_file does not have an association called '#{type}''" unless association
-
-            current_file = association.reader if update_existing
-            current_file ||= association.build
-          else
-            current_file = generic_file.filter_files_by_type(type_to_uri(type)).first if update_existing
-            unless current_file
-              generic_file.files.build
-              current_file = generic_file.files.last
-              Hydra::PCDM::AddTypeToFile.call(current_file, type_to_uri(type))
-            end
-          end
-        end
-
-        # Returns appropriate URI for the requested type
-        #  * Converts supported symbols to corresponding URIs
-        #  * Converts URI strings to RDF::URI
-        #  * Returns RDF::URI objects as-is
-        def type_to_uri(type)
-          case type
-          when ::RDF::URI
-            type
-          when String
-            ::RDF::URI(type)
-          else
-            raise ArgumentError, "Invalid file type.  You must submit a URI or a symbol."
-          end
-        end
-      end  
-
-      class VersioningUpdater < Updater
-        def update(*)
-          super && current_file.create_version
+      def persist
+        if current_file.new_record?
+          # persist current_file and its membership in generic_file.files container
+          generic_file.save
+        else
+          # we updated the content of an existing file, so we need to save the file explicitly
+          current_file.save
         end
       end
+
+      def attach_attributes(file)
+        current_file.content = file
+        current_file.original_name = determine_original_name(file)
+        current_file.mime_type = determine_mime_type(file)
+      end
+
+      # Return mime_type based on methods available to file
+      # @param object for mimetype to be determined. Attempts to use methods: :mime_type, :content_type, and :path.
+      def determine_mime_type(file)
+        if file.respond_to? :mime_type
+          return file.mime_type
+        elsif file.respond_to? :content_type
+          return file.content_type
+        elsif file.respond_to? :path
+          return Hydra::PCDM::GetMimeTypeForFile.call(file.path)
+        else
+          return 'application/octet-stream'
+        end
+      end
+
+      # Return original_name based on methods available to file
+      # @param object for original name to be determined. Attempts to use methods: :original_name, :original_filename, and :path.
+      def determine_original_name(file)
+        if file.respond_to? :original_name
+          return file.original_name
+        elsif file.respond_to? :original_filename
+          return file.original_filename
+        elsif file.respond_to? :path
+          return ::File.basename(file.path)
+        else
+          return ''
+        end
+      end
+
+      # @param [Symbol, RDF::URI] the type of association or filter to use
+      # @param [true, false] update_existing when true, try to retrieve existing element before building one
+      def find_or_create_file(type, update_existing)
+        if type.instance_of? Symbol
+          association = generic_file.association(type)
+          fail ArgumentError, "you're attempting to add a file to a generic_file using '#{type}' association but the generic_file does not have an association called '#{type}''" unless association
+
+          current_file = association.reader if update_existing
+          current_file || association.build
+        else
+          current_file = generic_file.filter_files_by_type(type_to_uri(type)).first if update_existing
+          unless current_file
+            generic_file.files.build
+            current_file = generic_file.files.last
+            Hydra::PCDM::AddTypeToFile.call(current_file, type_to_uri(type))
+          end
+        end
+      end
+
+      # Returns appropriate URI for the requested type
+      #  * Converts supported symbols to corresponding URIs
+      #  * Converts URI strings to RDF::URI
+      #  * Returns RDF::URI objects as-is
+      def type_to_uri(type)
+        case type
+        when ::RDF::URI
+          type
+        when String
+          ::RDF::URI(type)
+        else
+          fail ArgumentError, 'Invalid file type.  You must submit a URI or a symbol.'
+        end
+      end
+    end
+
+    class VersioningUpdater < Updater
+      def update(*)
+        super && current_file.create_version
+      end
+    end
   end
 end
-

--- a/lib/hydra/works/services/generic_file/generate/thumbnail.rb
+++ b/lib/hydra/works/services/generic_file/generate/thumbnail.rb
@@ -1,18 +1,13 @@
 module Hydra::Works
   class GenerateThumbnail
-
     def self.call(object, content: :original_file)
-      raise ArgumentError, "object has no content at #{content} from which to generate a thumbnail" if object.send(content).nil?
-      source = object.send(content)
+      fail ArgumentError, "object has no content at #{content} from which to generate a thumbnail" if object.send(content).nil?
 
       # Always replace the thumbnail with whatever is from the original file
-      if object.thumbnail.nil?
-        object.build_thumbnail
-      end
-      
+      object.build_thumbnail if object.thumbnail.nil?
+
       object.create_derivatives
       object
     end
-
   end
 end

--- a/lib/hydra/works/services/generic_file/persist_derivative.rb
+++ b/lib/hydra/works/services/generic_file/persist_derivative.rb
@@ -2,13 +2,12 @@ require 'hydra/derivatives'
 
 module Hydra::Works
   class PersistDerivative < Hydra::Derivatives::PersistOutputFileService
-
     ##
     # Persists a derivative to a GenericFile
-    # This Service conforms to the signature of `Hydra::Derivatives::PersistOutputFileService`.  
+    # This Service conforms to the signature of `Hydra::Derivatives::PersistOutputFileService`.
     # The purpose of this Service is for use as an alternative to the default Hydra::Derivatives::PersistOutputFileService.  It's necessary because the default behavior in Hydra::Derivatives assumes that you're using LDP Basic Containment. Hydra::Works::GenericFiles use IndirectContainment.  This Service handles that case.
     # This service will always update existing and does not do versioning of persisted files.
-    # 
+    #
     # @param [Hydra::Works::GenericFile::Base] object the file will be added to
     # @param [#read or String] file the derivative filestream optionally responds to :mime_type
     # @param [String] extract file type symbol (e.g. :thumbnail) from Hydra::Derivatives created destination_name
@@ -17,6 +16,5 @@ module Hydra::Works
       type = destination_name.gsub(/^original_file_/, '').to_sym
       Hydra::Works::AddFileToGenericFile.call(object, file, type, update_existing: true, versioning: false)
     end
-
   end
 end

--- a/lib/hydra/works/services/generic_file/upload_file.rb
+++ b/lib/hydra/works/services/generic_file/upload_file.rb
@@ -1,6 +1,5 @@
 module Hydra::Works
   class UploadFileToGenericFile
-
     # Sets a file as the primary file (original_file) of the generic_file
     # @param [Hydra::PCDM::GenericFile::Base] generic_file the file will be added to
     # @param [IO,File,Rack::Multipart::UploadedFile, #read] object that will be the contents. If file responds to :mime_type or :original_name, those will be called to provide technical metadata.
@@ -8,7 +7,7 @@ module Hydra::Works
     # @param [Boolean] update_existing whether to update an existing file if there is one. When set to true, performs a create_or_update. When set to false, always creates a new file within generic_file.files.
     # @param [Boolean] versioning whether to create new version entries (only applicable if +type+ corresponds to a versionable file)
 
-  def self.call(generic_file, file, additional_services: [], update_existing: true, versioning: true)
+    def self.call(generic_file, file, additional_services: [], update_existing: true, versioning: true)
       Hydra::Works::AddFileToGenericFile.call(generic_file, file, :original_file, update_existing: update_existing, versioning: versioning)
 
       # Call any additional services
@@ -19,6 +18,5 @@ module Hydra::Works
       generic_file.save
       generic_file
     end
-
   end
 end

--- a/lib/hydra/works/version.rb
+++ b/lib/hydra/works/version.rb
@@ -1,5 +1,5 @@
 module Hydra
   module Works
-    VERSION = "0.1.0"
+    VERSION = '0.1.0'
   end
 end

--- a/lib/hydra/works/vocab/works_terms.rb
+++ b/lib/hydra/works/vocab/works_terms.rb
@@ -1,12 +1,10 @@
 require 'rdf'
 module WorksVocabularies
-  class WorksTerms < RDF::Vocabulary("http://projecthydra.org/works/models#")
-
+  class WorksTerms < RDF::Vocabulary('http://projecthydra.org/works/models#')
     # Class definitions
     term :Collection
     term :GenericWork
     term :GenericFile
     term :File
-
   end
 end

--- a/spec/hydra/works/models/collection_spec.rb
+++ b/spec/hydra/works/models/collection_spec.rb
@@ -1,36 +1,35 @@
 require 'spec_helper'
 
 describe Hydra::Works::Collection do
+  subject { described_class.new }
 
-  subject { Hydra::Works::Collection.new }
-
-  let(:collection1) { Hydra::Works::Collection.new }
-  let(:collection2) { Hydra::Works::Collection.new }
-  let(:collection3) { Hydra::Works::Collection.new }
+  let(:collection1) { described_class.new }
+  let(:collection2) { described_class.new }
+  let(:collection3) { described_class.new }
 
   let(:generic_work1) { Hydra::Works::GenericWork::Base.new }
   let(:generic_work2) { Hydra::Works::GenericWork::Base.new }
   let(:generic_work3) { Hydra::Works::GenericWork::Base.new }
 
   describe '#child_collections' do
-    it 'should return empty array when only generic_works are aggregated' do
+    it 'returns empty array when only generic_works are aggregated' do
       subject.child_generic_works << generic_work1
       subject.child_generic_works << generic_work2
-      expect(subject.child_collections ).to eq []
+      expect(subject.child_collections).to eq []
     end
 
-    context 'with other collections & generic_works' do 
-      before do 
+    context 'with other collections & generic_works' do
+      before do
         subject.child_collections << collection1
         subject.child_collections << collection2
         subject.child_generic_works << generic_work1
         subject.child_generic_works << generic_work2
       end
 
-      it 'should only return collections' do
-        expect(subject.child_collections ).to eq [collection1,collection2]
+      it 'returns only collections' do
+        expect(subject.child_collections).to eq [collection1, collection2]
       end
-    end  
+    end
   end
 
   describe '#child_collections <<' do
@@ -43,9 +42,9 @@ describe Hydra::Works::Collection do
           subject.child_generic_works << generic_work2
         end
 
-        it 'should add an generic_work to collection with collections and generic_works' do
+        it 'adds an generic_work to collection with collections and generic_works' do
           subject.child_collections << collection3
-          expect( subject.child_collections ).to eq [collection1,collection2,collection3]
+          expect(subject.child_collections).to eq [collection1, collection2, collection3]
         end
       end
 
@@ -58,14 +57,14 @@ describe Hydra::Works::Collection do
         after { Object.send(:remove_const, :Kollection) }
         let(:kollection1) { Kollection.new }
 
-        it 'should accept implementing collection as a child' do
+        it 'accepts implementing collection as a child' do
           subject.child_collections << kollection1
-          expect( subject.child_collections ).to eq [kollection1]
+          expect(subject.child_collections).to eq [kollection1]
         end
 
-        it 'should accept implementing collection as a parent' do
+        it 'accepts implementing collection as a parent' do
           subject.child_collections << collection1
-          expect( subject.child_collections ).to eq [collection1]
+          expect(subject.child_collections).to eq [collection1]
         end
       end
 
@@ -77,63 +76,62 @@ describe Hydra::Works::Collection do
         after { Object.send(:remove_const, :Cullection) }
         let(:cullection1) { Cullection.new }
 
-        it 'should accept extending collection as a child' do
+        it 'accepts extending collection as a child' do
           subject.child_collections << cullection1
-          expect( subject.child_collections ).to eq [cullection1]
+          expect(subject.child_collections).to eq [cullection1]
         end
 
-        it 'should accept extending collection as a parent' do
+        it 'accepts extending collection as a parent' do
           subject.child_collections << collection1
-          expect( subject.child_collections ).to eq [collection1]
+          expect(subject.child_collections).to eq [collection1]
         end
       end
     end
 
     context 'with unacceptable inputs' do
       before(:all) do
-        @works_collection101  = Hydra::Works::Collection.new
+        @works_collection101  = described_class.new
         @generic_work101      = Hydra::Works::GenericWork::Base.new
         @generic_file101      = Hydra::Works::GenericFile::Base.new
         @pcdm_collection101   = Hydra::PCDM::Collection.new
         @pcdm_object101       = Hydra::PCDM::Object.new
         @pcdm_file101         = Hydra::PCDM::File.new
-        @non_PCDM_object      = "I'm not a PCDM object"
+        @non_pcdm_object      = "I'm not a PCDM object"
         @af_base_object       = ActiveFedora::Base.new
       end
 
       context 'that are unacceptable child collections' do
-
         let(:error_type1)    { ArgumentError }
         let(:error_message1) { /Hydra::Works::Generic(Work|File)::Base with ID:  was expected to works_collection\?, but it was false/ }
         let(:error_type2)    { NoMethodError }
         let(:error_message2) { /undefined method `works_collection\?' for .*/ }
 
-        it 'should NOT aggregate Hydra::Works::GenericWork in collections aggregation' do
-          expect{ subject.child_collections << @generic_work101 }.to raise_error(error_type1,error_message1)
+        it 'does not aggregate Hydra::Works::GenericWork in collections aggregation' do
+          expect { subject.child_collections << @generic_work101 }.to raise_error(error_type1, error_message1)
         end
 
-        it 'should NOT aggregate Hydra::Works::GenericFile in collections aggregation' do
-          expect{ subject.child_collections << @generic_file101 }.to raise_error(error_type1,error_message1)
+        it 'does not aggregate Hydra::Works::GenericFile in collections aggregation' do
+          expect { subject.child_collections << @generic_file101 }.to raise_error(error_type1, error_message1)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Collections in collections aggregation' do
-          expect{ subject.child_collections << @pcdm_collection101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Collections in collections aggregation' do
+          expect { subject.child_collections << @pcdm_collection101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Objects in collections aggregation' do
-          expect{ subject.child_collections << @pcdm_object101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Objects in collections aggregation' do
+          expect { subject.child_collections << @pcdm_object101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Files in collections aggregation' do
-          expect{ subject.child_collections << @pcdm_file101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Files in collections aggregation' do
+          expect { subject.child_collections << @pcdm_file101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate non-PCDM objects in collections aggregation' do
-          expect{ subject.child_collections << @non_PCDM_object }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate non-PCDM objects in collections aggregation' do
+          expect { subject.child_collections << @non_pcdm_object }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate AF::Base objects in collections aggregation' do
-          expect{ subject.child_collections << @af_base_object }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate AF::Base objects in collections aggregation' do
+          expect { subject.child_collections << @af_base_object }.to raise_error(error_type2, error_message2)
         end
       end
     end
@@ -147,52 +145,51 @@ describe Hydra::Works::Collection do
         subject.child_generic_works << generic_work2
         subject.child_collections << collection3
         subject.child_generic_works << generic_work1
-        expect( subject.child_collections ).to eq [collection1,collection2,collection3]
+        expect(subject.child_collections).to eq [collection1, collection2, collection3]
       end
-      
-      it 'should remove first collection' do
-        expect( subject.child_collections.delete collection1 ).to eq [collection1]
-        expect( subject.child_collections ).to eq [collection2,collection3]
-        expect( subject.child_generic_works ).to eq [generic_work2,generic_work1]    
+
+      it 'removes first collection' do
+        expect(subject.child_collections.delete collection1).to eq [collection1]
+        expect(subject.child_collections).to eq [collection2, collection3]
+        expect(subject.child_generic_works).to eq [generic_work2, generic_work1]
       end
-        
-      it 'should remove last collection' do
-        expect( subject.child_collections.delete collection3 ).to eq [collection3]
-        expect( subject.child_collections ).to eq [collection1,collection2]
-        expect( subject.child_generic_works). to eq [generic_work2,generic_work1]      
+
+      it 'removes last collection' do
+        expect(subject.child_collections.delete collection3).to eq [collection3]
+        expect(subject.child_collections).to eq [collection1, collection2]
+        expect(subject.child_generic_works). to eq [generic_work2, generic_work1]
       end
-   
-      it 'should remove middle collection' do
-        expect( subject.child_collections.delete collection2 ).to eq [collection2]
-        expect( subject.child_collections ).to eq [collection1,collection3]
-        expect( subject.child_generic_works). to eq [generic_work2,generic_work1]    
+
+      it 'removes middle collection' do
+        expect(subject.child_collections.delete collection2).to eq [collection2]
+        expect(subject.child_collections).to eq [collection1, collection3]
+        expect(subject.child_generic_works). to eq [generic_work2, generic_work1]
       end
-    end 
-  end   
+    end
+  end
 
   describe '#child_generic_works' do
-    it 'should return empty array when only collections are aggregated' do
+    it 'returns empty array when only collections are aggregated' do
       subject.child_collections << collection1
       subject.child_collections << collection2
       expect(subject.child_generic_works). to eq []
     end
 
     context 'with collections and generic works' do
-      before do 
+      before do
         subject.child_collections << collection1
         subject.child_collections << collection2
         subject.child_generic_works << generic_work1
         subject.child_generic_works << generic_work2
       end
 
-      it 'should only return generic works' do
-        expect(subject.child_generic_works). to eq [generic_work1,generic_work2]     
+      it 'returns only generic works' do
+        expect(subject.child_generic_works). to eq [generic_work1, generic_work2]
       end
     end
-  end 
+  end
 
   describe '#child_generic_works <<' do
-    
     context 'with acceptable generic_works' do
       context 'with collections and generic_works' do
         before do
@@ -202,12 +199,12 @@ describe Hydra::Works::Collection do
           subject.child_generic_works << generic_work2
         end
 
-        it 'should add generic_work to collection with collections and generic_works' do 
+        it 'adds generic_work to collection with collections and generic_works' do
           subject.child_generic_works << generic_work3
-          expect( subject.child_generic_works  ).to eq [generic_work1,generic_work2,generic_work3]
+          expect(subject.child_generic_works).to eq [generic_work1, generic_work2, generic_work3]
         end
       end
-      
+
       describe 'aggregates generic_works that implement Hydra::Works' do
         before do
           class DummyIncWork < ActiveFedora::Base
@@ -216,12 +213,12 @@ describe Hydra::Works::Collection do
         end
         after { Object.send(:remove_const, :DummyIncWork) }
         let(:iwork1) { DummyIncWork.new }
-        
-        it 'should accept implementing generic_work as a child' do
+
+        it 'accepts implementing generic_work as a child' do
           subject.child_generic_works << iwork1
-          expect( subject.child_generic_works  ).to eq [iwork1]
+          expect(subject.child_generic_works).to eq [iwork1]
         end
-      end 
+      end
 
       describe 'aggregates generic_works that extend Hydra::Works' do
         before do
@@ -231,58 +228,57 @@ describe Hydra::Works::Collection do
         after { Object.send(:remove_const, :DummyExtWork) }
         let(:ework1) { DummyExtWork.new }
 
-        it 'should accept extending generic_work as a child' do
+        it 'accepts extending generic_work as a child' do
           subject.child_generic_works << ework1
-          expect( subject.child_generic_works  ).to eq [ework1]
+          expect(subject.child_generic_works).to eq [ework1]
         end
       end
     end
 
     context 'with unacceptable inputs' do
       before(:all) do
-        @works_collection101  = Hydra::Works::Collection.new
-        @works_collection102  = Hydra::Works::Collection.new
+        @works_collection101  = described_class.new
+        @works_collection102  = described_class.new
         @generic_file101      = Hydra::Works::GenericFile::Base.new
         @pcdm_collection101   = Hydra::PCDM::Collection.new
         @pcdm_object101       = Hydra::PCDM::Object.new
         @pcdm_file101         = Hydra::PCDM::File.new
-        @non_PCDM_object      = "I'm not a PCDM object"
+        @non_pcdm_object      = "I'm not a PCDM object"
         @af_base_object       = ActiveFedora::Base.new
       end
 
       context 'that are unacceptable child generic works' do
-
         let(:error_type1)    { ArgumentError }
         let(:error_message1) { /Hydra::Works::(GenericFile::Base|Collection) with ID:  was expected to works_generic_work\?, but it was false/ }
         let(:error_type2)    { NoMethodError }
         let(:error_message2) { /undefined method `works_generic_work\?' for .*/ }
 
-        it 'should NOT aggregate Hydra::Works::Collection in generic works aggregation' do
-          expect{ subject.child_generic_works << @works_collection101 }.to raise_error(error_type1,error_message1)
+        it 'does not aggregate Hydra::Works::Collection in generic works aggregation' do
+          expect { subject.child_generic_works << @works_collection101 }.to raise_error(error_type1, error_message1)
         end
 
-        it 'should NOT aggregate Hydra::Works::GenericFile in generic works aggregation' do
-          expect{ subject.child_generic_works << @generic_file101 }.to raise_error(error_type1,error_message1)
+        it 'does not aggregate Hydra::Works::GenericFile in generic works aggregation' do
+          expect { subject.child_generic_works << @generic_file101 }.to raise_error(error_type1, error_message1)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Collections in generic works aggregation' do
-          expect{ subject.child_generic_works << @pcdm_collection101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Collections in generic works aggregation' do
+          expect { subject.child_generic_works << @pcdm_collection101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Objects in generic works aggregation' do
-          expect{ subject.child_generic_works << @pcdm_object101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Objects in generic works aggregation' do
+          expect { subject.child_generic_works << @pcdm_object101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Files in generic works aggregation' do
-          expect{ subject.child_generic_works << @pcdm_file101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Files in generic works aggregation' do
+          expect { subject.child_generic_works << @pcdm_file101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate non-PCDM objects in generic works aggregation' do
-          expect{ subject.child_generic_works << @non_PCDM_object }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate non-PCDM objects in generic works aggregation' do
+          expect { subject.child_generic_works << @non_pcdm_object }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate AF::Base objects in generic works aggregation' do
-          expect{ subject.child_generic_works << @af_base_object }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate AF::Base objects in generic works aggregation' do
+          expect { subject.child_generic_works << @af_base_object }.to raise_error(error_type2, error_message2)
         end
       end
     end
@@ -296,28 +292,28 @@ describe Hydra::Works::Collection do
         subject.child_collections << collection2
         subject.child_generic_works << generic_work3
         subject.child_collections << collection1
-        expect( subject.child_generic_works). to eq [generic_work1,generic_work2,generic_work3]
+        expect(subject.child_generic_works). to eq [generic_work1, generic_work2, generic_work3]
       end
-      
-      it 'should remove first generic work' do
-        expect( subject.child_generic_works.delete generic_work1 ).to eq [generic_work1]
-        expect( subject.child_generic_works). to eq [generic_work2,generic_work3]
-        expect( subject.child_collections ).to eq [collection2,collection1]
+
+      it 'removes first generic work' do
+        expect(subject.child_generic_works.delete generic_work1).to eq [generic_work1]
+        expect(subject.child_generic_works). to eq [generic_work2, generic_work3]
+        expect(subject.child_collections).to eq [collection2, collection1]
       end
-        
-      it 'should remove last generic work' do
-        expect( subject.child_generic_works.delete generic_work3 ).to eq [generic_work3]
-        expect( subject.child_generic_works). to eq [generic_work1,generic_work2]
-        expect( subject.child_collections ).to eq [collection2,collection1]
+
+      it 'removes last generic work' do
+        expect(subject.child_generic_works.delete generic_work3).to eq [generic_work3]
+        expect(subject.child_generic_works). to eq [generic_work1, generic_work2]
+        expect(subject.child_collections).to eq [collection2, collection1]
       end
-   
-      it 'should remove middle generic work' do
-        expect( subject.child_generic_works.delete generic_work2 ).to eq [generic_work2]
-        expect( subject.child_generic_works). to eq [generic_work1,generic_work3]
-        expect( subject.child_collections ).to eq [collection2,collection1]
+
+      it 'removes middle generic work' do
+        expect(subject.child_generic_works.delete generic_work2).to eq [generic_work2]
+        expect(subject.child_generic_works). to eq [generic_work1, generic_work3]
+        expect(subject.child_collections).to eq [collection2, collection1]
       end
-    end 
-  end   
+    end
+  end
 
   describe '#related_objects' do
     let(:generic_file1) { Hydra::Works::GenericFile::Base.new }
@@ -330,47 +326,46 @@ describe Hydra::Works::Collection do
         subject.child_collections << collection2
         subject.child_generic_works << generic_work1
       end
-        
-      it 'should return empty array when only collections and generic works are aggregated' do
-        expect(subject.related_objects ).to eq []
+
+      it 'returns empty array when only collections and generic works are aggregated' do
+        expect(subject.related_objects).to eq []
       end
-      
-      it 'should only return related objects' do
+
+      it 'returns only related objects' do
         subject.related_objects << object2
-        expect(subject.related_objects ).to eq [object2]
+        expect(subject.related_objects).to eq [object2]
       end
-  
-      it 'should return related objects of various types' do
+
+      it 'returns related objects of various types' do
         subject.related_objects << generic_work2
         subject.related_objects << generic_file1
         subject.related_objects << object1
         subject.save
         subject.reload
-        expect( subject.related_objects.include? object1 ).to be true
-        expect( subject.related_objects.include? generic_work2 ).to be true
-        expect( subject.related_objects.include? generic_file1 ).to be true
-        expect( subject.related_objects.size ).to eq 3
+        expect(subject.related_objects.include? object1).to be true
+        expect(subject.related_objects.include? generic_work2).to be true
+        expect(subject.related_objects.include? generic_file1).to be true
+        expect(subject.related_objects.size).to eq 3
       end
     end
   end
 
   describe '#related_objects <<' do
-
     context 'with acceptable related objects' do
       let(:object1) { Hydra::PCDM::Object.new }
       let(:object2) { Hydra::PCDM::Object.new }
       let(:generic_file1) { Hydra::Works::GenericFile::Base.new }
 
-      it 'should add various types of related objects to collection' do
+      it 'adds various types of related objects to collection' do
         subject.related_objects << generic_work1
         subject.related_objects << generic_file1
         subject.related_objects << object1
         subject.save
         subject.reload
-        expect( subject.related_objects.include? generic_work1 ).to be true
-        expect( subject.related_objects.include? generic_file1 ).to be true
-        expect( subject.related_objects.include? object1 ).to be true
-        expect( subject.related_objects.size ).to eq 3
+        expect(subject.related_objects.include? generic_work1).to be true
+        expect(subject.related_objects.include? generic_file1).to be true
+        expect(subject.related_objects.include? object1).to be true
+        expect(subject.related_objects.size).to eq 3
       end
 
       context 'with collections and generic_works' do
@@ -382,13 +377,13 @@ describe Hydra::Works::Collection do
           subject.related_objects << object1
         end
 
-        it 'should add a related object to collection with collections and generic_works' do
+        it 'adds a related object to collection with collections and generic_works' do
           subject.related_objects << object2
           subject.save
           subject.reload
-          expect( subject.related_objects.include? object1 ).to be true
-          expect( subject.related_objects.include? object2 ).to be true
-          expect( subject.related_objects.size ).to eq 2
+          expect(subject.related_objects.include? object1).to be true
+          expect(subject.related_objects.include? object2).to be true
+          expect(subject.related_objects.size).to eq 2
         end
       end
     end
@@ -399,24 +394,24 @@ describe Hydra::Works::Collection do
       let(:non_PCDM_object)  { "I'm not a PCDM object" }
       let(:af_base_object)   { ActiveFedora::Base.new }
 
-      it 'should NOT aggregate Hydra::Works::Collection in related objects aggregation' do
-        expect{ subject.related_objects << collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::Works::Collection:.*> is not a PCDM object./)
+      it 'does not aggregate Hydra::Works::Collection in related objects aggregation' do
+        expect { subject.related_objects << collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::Works::Collection:.*> is not a PCDM object./)
       end
 
-      it 'should NOT aggregate Hydra::PCDM::Collections in related objects aggregation' do
-        expect{ subject.related_objects << pcdm_collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::PCDM::Collection:.* is not a PCDM object./)
+      it 'does not aggregate Hydra::PCDM::Collections in related objects aggregation' do
+        expect { subject.related_objects << pcdm_collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::PCDM::Collection:.* is not a PCDM object./)
       end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in related objects aggregation' do
-        expect{ subject.related_objects << pcdm_file1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got Hydra::PCDM::File.*/)
+      it 'does not aggregate Hydra::PCDM::Files in related objects aggregation' do
+        expect { subject.related_objects << pcdm_file1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got Hydra::PCDM::File.*/)
       end
 
-      it 'should NOT aggregate non-PCDM objects in related objects aggregation' do
-        expect{ subject.related_objects << non_PCDM_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got String.*/)
+      it 'does not aggregate non-PCDM objects in related objects aggregation' do
+        expect { subject.related_objects << non_PCDM_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got String.*/)
       end
 
-      it 'should NOT aggregate AF::Base objects in related objects aggregation' do
-        expect{ subject.related_objects << af_base_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* is not a PCDM object./)
+      it 'does not aggregate AF::Base objects in related objects aggregation' do
+        expect { subject.related_objects << af_base_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* is not a PCDM object./)
       end
     end
 
@@ -424,16 +419,16 @@ describe Hydra::Works::Collection do
       let(:object1) { Hydra::PCDM::Object.new }
       let(:object2) { Hydra::PCDM::Object.new }
 
-      it 'should NOT allow related objects to repeat' do
+      it 'does not allow related objects to repeat' do
         skip 'skipping this test because issue pcdm#92 needs to be addressed' do
-        subject.related_objects << object1
-        subject.related_objects << object2
-        subject.related_objects << object1
-        related_objects = subject.related_objects
-        expect( related_objects.include? object1 ).to be true
-        expect( related_objects.include? object2 ).to be true
-        expect( related_objects.size ).to eq 2
-      end
+          subject.related_objects << object1
+          subject.related_objects << object2
+          subject.related_objects << object1
+          related_objects = subject.related_objects
+          expect(related_objects.include? object1).to be true
+          expect(related_objects.include? object2).to be true
+          expect(related_objects.size).to eq 2
+        end
       end
     end
   end
@@ -455,49 +450,49 @@ describe Hydra::Works::Collection do
         subject.related_objects << related_object4
         subject.child_collections << collection1
         subject.related_objects << related_work5
-        expect( subject.related_objects ).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
-      end
-        
-      it 'should remove first related object' do
-        expect( subject.related_objects.delete related_object1 ).to eq [related_object1]
-        expect( subject.related_objects ).to eq [related_work2,related_file3,related_object4,related_work5]
-        expect( subject.child_collections ).to eq [collection2,collection1]
-        expect( subject.child_generic_works). to eq [generic_work1]
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_file3, related_object4, related_work5]
       end
 
-      it 'should remove last related object' do
-        expect( subject.related_objects.delete related_work5 ).to eq [related_work5]
-        expect( subject.related_objects ).to eq [related_object1,related_work2,related_file3,related_object4]
-        expect( subject.child_collections ).to eq [collection2,collection1]
-        expect( subject.child_generic_works). to eq [generic_work1]
+      it 'removes first related object' do
+        expect(subject.related_objects.delete related_object1).to eq [related_object1]
+        expect(subject.related_objects).to eq [related_work2, related_file3, related_object4, related_work5]
+        expect(subject.child_collections).to eq [collection2, collection1]
+        expect(subject.child_generic_works). to eq [generic_work1]
       end
-        
-      it 'should remove middle related object' do
-        expect( subject.related_objects.delete related_file3 ).to eq [related_file3]
-        expect( subject.related_objects ).to eq [related_object1,related_work2,related_object4,related_work5]
-        expect( subject.child_collections ).to eq [collection2,collection1]
-        expect( subject.child_generic_works). to eq [generic_work1]
+
+      it 'removes last related object' do
+        expect(subject.related_objects.delete related_work5).to eq [related_work5]
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_file3, related_object4]
+        expect(subject.child_collections).to eq [collection2, collection1]
+        expect(subject.child_generic_works). to eq [generic_work1]
       end
-    end 
-  end   
+
+      it 'removes middle related object' do
+        expect(subject.related_objects.delete related_file3).to eq [related_file3]
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_object4, related_work5]
+        expect(subject.child_collections).to eq [collection2, collection1]
+        expect(subject.child_generic_works). to eq [generic_work1]
+      end
+    end
+  end
 
   describe '#collections=' do
-    it 'should aggregate collections' do
+    it 'aggregates collections' do
       collection1.child_collections = [collection2, collection3]
       expect(collection1.child_collections).to eq [collection2, collection3]
     end
   end
 
   describe '#child_generic_works=' do
-    it 'should aggregate generic_works' do
-      collection1.child_generic_works = [generic_work1,generic_work2]
-      expect(collection1.child_generic_works).to eq [generic_work1,generic_work2]
+    it 'aggregates generic_works' do
+      collection1.child_generic_works = [generic_work1, generic_work2]
+      expect(collection1.child_generic_works).to eq [generic_work1, generic_work2]
     end
   end
 
   describe 'Related objects' do
     let(:object) { Hydra::PCDM::Object.new }
-    let(:collection) { Hydra::Works::Collection.new }
+    let(:collection) { described_class.new }
 
     before do
       collection.related_objects = [object]
@@ -508,16 +503,16 @@ describe Hydra::Works::Collection do
     end
   end
 
-  describe "should have parent collection accessors" do
+  describe 'should have parent collection accessors' do
     before do
       collection1.child_collections << collection2
       collection1.save
     end
 
-    it 'should have parents' do
+    it 'has parents' do
       expect(collection2.parents).to eq [collection1]
     end
-    it 'should have a parent collection' do
+    it 'has a parent collection' do
       expect(collection2.parent_collections).to eq [collection1]
     end
   end

--- a/spec/hydra/works/models/concerns/block_child_objects_spec.rb
+++ b/spec/hydra/works/models/concerns/block_child_objects_spec.rb
@@ -1,19 +1,17 @@
 require 'spec_helper'
 
 describe Hydra::Works::BlockChildObjects do
-
   subject { Hydra::Works::GenericFile::Base.new }
 
-  describe "#child_objects=?" do
-    it "should raise an error" do
+  describe '#child_objects=?' do
+    it 'raises an error' do
       expect { subject.child_objects = [] }.to raise_error(StandardError, /method `child_objects=' not allowed for #<Hydra::Works::GenericFile::Base.*/)
     end
   end
 
-  describe "#child_objects" do
-    it "should raise an error" do
+  describe '#child_objects' do
+    it 'raises an error' do
       expect { subject.child_objects }.to raise_error(StandardError, /method `child_objects' not allowed for #<Hydra::Works::GenericFile::Base.*/)
     end
   end
-
 end

--- a/spec/hydra/works/models/concerns/generic_file/contained_files_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file/contained_files_spec.rb
@@ -1,116 +1,108 @@
 require 'spec_helper'
 
 describe Hydra::Works::GenericFile::ContainedFiles do
-
   let(:generic_file) do
     Hydra::Works::GenericFile::Base.create
   end
 
-  let(:thumbnail)   do
+  let(:thumbnail) do
     file = generic_file.files.build
     Hydra::PCDM::AddTypeToFile.call(file, pcdm_thumbnail_uri)
   end
 
   let(:file)                { generic_file.files.build }
-  let(:pcdm_thumbnail_uri)  { ::RDF::URI("http://pcdm.org/use#ThumbnailImage") }
+  let(:pcdm_thumbnail_uri)  { ::RDF::URI('http://pcdm.org/use#ThumbnailImage') }
 
   before do
     generic_file.files = [file]
   end
 
-  describe "#thumbnail" do
-
-    context "when a thumbnail is present" do
+  describe '#thumbnail' do
+    context 'when a thumbnail is present' do
       before do
         original_file = generic_file.build_thumbnail
-        original_file.content = "thumbnail"
+        original_file.content = 'thumbnail'
       end
       subject { generic_file.thumbnail }
-      it "can be saved without errors" do
+      it 'can be saved without errors' do
         expect(subject.save).to be_truthy
       end
-      it "retrieves content of the thumbnail" do
-        expect(subject.content).to eql "thumbnail"
+      it 'retrieves content of the thumbnail' do
+        expect(subject.content).to eql 'thumbnail'
       end
-      it "retains origin pcdm.File RDF type" do
-        expect(subject.metadata_node.type).to include( ::RDF::URI("http://pcdm.org/use#ThumbnailImage") )
+      it 'retains origin pcdm.File RDF type' do
+        expect(subject.metadata_node.type).to include(::RDF::URI('http://pcdm.org/use#ThumbnailImage'))
         expect(subject.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
       end
     end
 
-    context "when building new thumbnail" do
+    context 'when building new thumbnail' do
       subject { generic_file.build_thumbnail }
-      it "initializes an unsaved File object with Thumbnail type" do
+      it 'initializes an unsaved File object with Thumbnail type' do
         expect(subject).to be_new_record
         expect(subject.metadata_node.type).to include(pcdm_thumbnail_uri)
         expect(subject.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
       end
     end
-
   end
 
-  describe "#original_file" do
-
-    context "when an original file is present" do
+  describe '#original_file' do
+    context 'when an original file is present' do
       before do
         original_file = generic_file.build_original_file
-        original_file.content = "original_file"
+        original_file.content = 'original_file'
       end
       subject { generic_file.original_file }
 
-      it "can be saved without errors" do
+      it 'can be saved without errors' do
         expect(subject.save).to be_truthy
       end
-      it "retrieves content of the original_file as a PCDM File" do
-        expect(subject.content).to eql "original_file"
+      it 'retrieves content of the original_file as a PCDM File' do
+        expect(subject.content).to eql 'original_file'
         expect(subject).to be_instance_of Hydra::PCDM::File
       end
-      it "retains origin pcdm.File RDF type" do
-        expect(subject.metadata_node.type).to include(::RDF::URI("http://pcdm.org/use#OriginalFile") )
+      it 'retains origin pcdm.File RDF type' do
+        expect(subject.metadata_node.type).to include(::RDF::URI('http://pcdm.org/use#OriginalFile'))
         expect(generic_file.original_file.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
       end
     end
 
-    context "when building original file" do
+    context 'when building original file' do
       subject { generic_file.build_original_file }
-      it "initializes an unsaved File object with OrignalFile type" do
+      it 'initializes an unsaved File object with OrignalFile type' do
         expect(subject).to be_new_record
-        expect(subject.metadata_node.type).to include(::RDF::URI("http://pcdm.org/use#OriginalFile") )
+        expect(subject.metadata_node.type).to include(::RDF::URI('http://pcdm.org/use#OriginalFile'))
         expect(subject.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
       end
     end
-
   end
 
-  describe "#extracted_text" do
-
-    context "when extracted text is present" do
+  describe '#extracted_text' do
+    context 'when extracted text is present' do
       before do
         extracted_text = generic_file.build_extracted_text
-        extracted_text.content = "extracted_text"
+        extracted_text.content = 'extracted_text'
       end
       subject { generic_file.extracted_text }
-      it "can be saved without errors" do
+      it 'can be saved without errors' do
         expect(subject.save).to be_truthy
       end
-      it "retrieves content of the extracted_text" do
-        expect(subject.content).to eql "extracted_text"
+      it 'retrieves content of the extracted_text' do
+        expect(subject.content).to eql 'extracted_text'
       end
-      it "retains origin pcdm.File RDF type" do
-        expect(subject.metadata_node.type).to include(::RDF::URI("http://pcdm.org/use#ExtractedText") )
+      it 'retains origin pcdm.File RDF type' do
+        expect(subject.metadata_node.type).to include(::RDF::URI('http://pcdm.org/use#ExtractedText'))
         expect(subject.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
       end
     end
 
-    context "when building new extracted text object" do
+    context 'when building new extracted text object' do
       subject { generic_file.build_extracted_text }
-      it "initializes an unsaved File object with ExtractedText type" do
+      it 'initializes an unsaved File object with ExtractedText type' do
         expect(subject).to be_new_record
-        expect(subject.metadata_node.type).to include(::RDF::URI("http://pcdm.org/use#ExtractedText") )
+        expect(subject.metadata_node.type).to include(::RDF::URI('http://pcdm.org/use#ExtractedText'))
         expect(subject.metadata_node.type).to include(RDFVocabularies::PCDMTerms.File)
       end
     end
-
   end
-
 end

--- a/spec/hydra/works/models/concerns/generic_file/mime_types_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file/mime_types_spec.rb
@@ -1,76 +1,74 @@
 require 'spec_helper'
 
 describe Hydra::Works::GenericFile::MimeTypes do
-
   subject { Hydra::Works::GenericFile::Base.new }
 
-  describe "#pdf?" do
+  describe '#pdf?' do
     before do
       allow(subject).to receive(:mime_type).and_return('application/pdf')
     end
-    it "should be true" do
+    it 'is true' do
       expect(subject.pdf?).to be true
     end
   end
 
-  describe "#image?" do
+  describe '#image?' do
     before do
       allow(subject).to receive(:mime_type).and_return('image/jpeg')
     end
-    it "should be true" do
+    it 'is true' do
       expect(subject.image?).to be true
     end
   end
 
-  describe "#video?" do
+  describe '#video?' do
     before do
       allow(subject).to receive(:mime_type).and_return('video/mp4')
     end
-    it "should be true" do
+    it 'is true' do
       expect(subject.video?).to be true
     end
   end
 
-  describe "#audio?" do
+  describe '#audio?' do
     before do
       allow(subject).to receive(:mime_type).and_return('audio/mp3')
     end
-    it "should be true" do
+    it 'is true' do
       expect(subject.audio?).to be true
     end
   end
 
-  describe "#office_document?" do
+  describe '#office_document?' do
     before do
       allow(subject).to receive(:mime_type).and_return('application/msword')
     end
-    it "should be true" do
+    it 'is true' do
       expect(subject.office_document?).to be true
     end
   end
 
-  describe "#collection?" do
-    it "should be false" do
+  describe '#collection?' do
+    it 'is false' do
       expect(subject.collection?).to be false
     end
   end
 
-  describe "#file_format?" do
-    it "should handle both mime and format_label" do
+  describe '#file_format?' do
+    it 'handles both mime and format_label' do
       allow(subject).to receive(:mime_type).and_return('image/png')
       allow(subject).to receive(:format_label).and_return(['Portable Network Graphics'])
       expect(subject.file_format).to eq 'png (Portable Network Graphics)'
     end
-    it "should handle just mime type" do
+    it 'handles just mime type' do
       allow(subject).to receive(:mime_type).and_return('image/png')
       allow(subject).to receive(:format_label).and_return([])
       expect(subject.file_format).to eq 'png'
     end
-    it "should handle just format_label" do
+    it 'handles just format_label' do
       allow(subject).to receive(:mime_type).and_return('')
       allow(subject).to receive(:format_label).and_return(['Portable Network Graphics'])
       expect(subject.file_format).to eq ['Portable Network Graphics']
     end
   end
-
 end

--- a/spec/hydra/works/models/concerns/generic_file/versioned_content_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file/versioned_content_spec.rb
@@ -1,31 +1,31 @@
 require 'spec_helper'
 
 describe Hydra::Works::GenericFile::VersionedContent do
-  let(:generic_file)  { Hydra::Works::GenericFile::Base.new }
+  let(:generic_file) { Hydra::Works::GenericFile::Base.new }
   before do
-    Hydra::Works::UploadFileToGenericFile.call(generic_file, File.open(File.join(fixture_path, "sample-file.pdf")))
-    Hydra::Works::UploadFileToGenericFile.call(generic_file, File.open(File.join(fixture_path, "updated-file.txt")))
+    Hydra::Works::UploadFileToGenericFile.call(generic_file, File.open(File.join(fixture_path, 'sample-file.pdf')))
+    Hydra::Works::UploadFileToGenericFile.call(generic_file, File.open(File.join(fixture_path, 'updated-file.txt')))
   end
 
-  describe "content_versions" do
-    subject {generic_file.content_versions}
-    it "lists all of the versions of original_file" do
+  describe 'content_versions' do
+    subject { generic_file.content_versions }
+    it 'lists all of the versions of original_file' do
       expect(subject.count).to eq(2)
-      expect(subject.map { |v| v.uri }).to eq(generic_file.original_file.versions.all.map { |v| v.uri })
+      expect(subject.map(&:uri)).to eq(generic_file.original_file.versions.all.map(&:uri))
     end
   end
 
-  describe "latest_content_version" do
+  describe 'latest_content_version' do
     subject { generic_file.latest_content_version }
-    it "returns the most recent version entry for original_file" do
+    it 'returns the most recent version entry for original_file' do
       # Can't use a simple equivalence because they are actually different ResourceVersion objects
       expect(subject.uri).to eq(generic_file.original_file.versions.last.uri)
       expect(subject.label).to eq(generic_file.original_file.versions.last.label)
     end
   end
 
-  describe "current_content_version_uri" do
-    it "returns the URI of the most recent version of original_file" do
+  describe 'current_content_version_uri' do
+    it 'returns the URI of the most recent version of original_file' do
       expect(generic_file.current_content_version_uri).to eq(generic_file.original_file.versions.last.uri)
     end
   end

--- a/spec/hydra/works/models/concerns/generic_file/virus_check_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file/virus_check_spec.rb
@@ -7,8 +7,12 @@ describe Hydra::Works::GenericFile::VirusCheck do
       include Hydra::Works::GenericFile::VirusCheck
     end
     class ClamAV
-      def self.instance; @instance ||= ClamAV.new; end
-      def scanfile(path); puts "scanfile: #{path}"; end
+      def self.instance
+        @instance ||= ClamAV.new
+      end
+      def scanfile(path)
+        puts "scanfile: #{path}"
+      end
     end
   end
   after do
@@ -25,26 +29,24 @@ describe Hydra::Works::GenericFile::VirusCheck do
   end
 
   context 'with an infected file' do
-
     before do
       expect(ClamAV.instance).to receive(:scanfile).and_return(1)
     end
-    it "should fail to save" do
+    it 'fails to save' do
       expect(subject.save).to eq false
     end
-    it "should fail to validate" do
+    it 'fails to validate' do
       expect(subject.validate).to eq false
     end
   end
 
-  context "with a clean file" do
+  context 'with a clean file' do
     before do
       expect(ClamAV.instance).to receive(:scanfile).and_return(0)
     end
 
-    it "should not detect viruses" do
+    it 'does not detect viruses' do
       expect(subject.detect_viruses).to eq true
     end
   end
-
 end

--- a/spec/hydra/works/models/concerns/generic_file_behavior_spec.rb
+++ b/spec/hydra/works/models/concerns/generic_file_behavior_spec.rb
@@ -6,7 +6,7 @@ describe Hydra::Works::GenericFileBehavior do
   end
   subject { IncludesGenericFileBehavior.new }
 
-  it "ensures that objects will be recognized as generic_files" do
+  it 'ensures that objects will be recognized as generic_files' do
     expect(subject).to be_works_generic_file
   end
 end

--- a/spec/hydra/works/models/generic_file_spec.rb
+++ b/spec/hydra/works/models/generic_file_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe Hydra::Works::GenericFile::Base do
-
-  let(:generic_file1) { Hydra::Works::GenericFile::Base.new }
+  let(:generic_file1) { described_class.new }
 
   describe 'Related objects' do
     let(:object1) { Hydra::PCDM::Object.new }
@@ -23,7 +22,7 @@ describe Hydra::Works::GenericFile::Base do
 
     before do
       file1.content = "I'm a file"
-      file2.content = "I am too"
+      file2.content = 'I am too'
       object.save!
     end
 
@@ -33,50 +32,48 @@ describe Hydra::Works::GenericFile::Base do
   end
 
   describe 'add related object' do
-
-    let(:subject) { Hydra::Works::GenericFile::Base.new }
+    let(:subject) { described_class.new }
 
     describe 'begin test' do
-
       context 'with acceptable related objects' do
         let(:object1) { Hydra::PCDM::Object.create }
         let(:object2) { Hydra::PCDM::Object.new }
         let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
         let(:generic_work2) { Hydra::Works::GenericWork::Base.new }
-        let(:generic_file1) { Hydra::Works::GenericFile::Base.create }
+        let(:generic_file1) { described_class.create }
 
-        it 'should add various types of related objects to generic_file' do
+        it 'adds various types of related objects to generic_file' do
           subject.related_objects << generic_work1
           subject.related_objects << generic_file1
           subject.related_objects << object1
           subject.save
           subject.reload
           related_objects = subject.related_objects
-          expect( related_objects.include? generic_work1 ).to be true
-          expect( related_objects.include? generic_file1 ).to be true
-          expect( related_objects.include? object1 ).to be true
-          expect( related_objects.size ).to eq 3
+          expect(related_objects.include? generic_work1).to be true
+          expect(related_objects.include? generic_file1).to be true
+          expect(related_objects.include? object1).to be true
+          expect(related_objects.size).to eq 3
         end
 
         context 'with files and generic_files' do
           let(:file1) { subject.files.build }
           let(:file2) { subject.files.build }
-          
+
           before do
             subject.save
             file1.content = "I'm a file"
-            file2.content = "I am too"
+            file2.content = 'I am too'
             subject.related_objects << object1
           end
 
-          it 'should add a related object to a generic_file with files and generic_files' do
-            subject.related_objects << object2 
+          it 'adds a related object to a generic_file with files and generic_files' do
+            subject.related_objects << object2
             subject.save
             subject.reload
             related_objects = subject.related_objects
-            expect( related_objects.include? object1 ).to be true
-            expect( related_objects.include? object2 ).to be true
-            expect( related_objects.size ).to eq 2
+            expect(related_objects.include? object1).to be true
+            expect(related_objects.include? object2).to be true
+            expect(related_objects.size).to eq 2
           end
         end
       end
@@ -87,146 +84,139 @@ describe Hydra::Works::GenericFile::Base do
         let(:pcdm_file1)       { Hydra::PCDM::File.new }
         let(:non_PCDM_object)  { "I'm not a PCDM object" }
         let(:af_base_object)   { ActiveFedora::Base.new }
-        
+
         let(:error_message) { 'child_related_object must be a pcdm object' }
-        
-        it 'should NOT aggregate Hydra::Works::Collection in related objects aggregation' do
-          expect{ subject.related_objects << collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::Works::Collection:.*> is not a PCDM object./)
+
+        it 'does not aggregate Hydra::Works::Collection in related objects aggregation' do
+          expect { subject.related_objects << collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::Works::Collection:.*> is not a PCDM object./)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Collections in related objects aggregation' do
-          expect{ subject.related_objects << pcdm_collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::PCDM::Collection:.*> is not a PCDM object./)
+        it 'does not aggregate Hydra::PCDM::Collections in related objects aggregation' do
+          expect { subject.related_objects << pcdm_collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::PCDM::Collection:.*> is not a PCDM object./)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Files in related objects aggregation' do
-          expect{ subject.related_objects << pcdm_file1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got Hydra::PCDM::File.*/)
+        it 'does not aggregate Hydra::PCDM::Files in related objects aggregation' do
+          expect { subject.related_objects << pcdm_file1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got Hydra::PCDM::File.*/)
         end
 
-        it 'should NOT aggregate non-PCDM objects in related objects aggregation' do
-          expect{ subject.related_objects << non_PCDM_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got String.*/)
+        it 'does not aggregate non-PCDM objects in related objects aggregation' do
+          expect { subject.related_objects << non_PCDM_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got String.*/)
+        end
+
+        it 'does not aggregate AF::Base objects in related objects aggregation' do
+          expect { subject.related_objects << af_base_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* is not a PCDM object./)
+        end
       end
-        
-        it 'should NOT aggregate AF::Base objects in related objects aggregation' do
-          expect{ subject.related_objects << af_base_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* is not a PCDM object./)
-          
-        end
-      end
-      
+
       context 'with invalid behaviors' do
         let(:object1) { Hydra::PCDM::Object.new }
         let(:object2) { Hydra::PCDM::Object.new }
 
-        it 'should NOT allow related objects to repeat' do
+        it 'does not allow related objects to repeat' do
           skip 'skipping this test because issue pcdm#92 needs to be addressed' do
-            subject.related_objects << object1   
+            subject.related_objects << object1
             subject.related_objects << object2
             subject.related_objects << object1
             subject.save
             subject.reload
             related_objects = subject.related_objects
-            expect( related_objects.include? object1 ).to be true
-            expect( related_objects.include? object2 ).to be true
-            expect( related_objects.size ).to eq 2
+            expect(related_objects.include? object1).to be true
+            expect(related_objects.include? object2).to be true
+            expect(related_objects.size).to eq 2
           end
         end
       end
     end
   end
- 
-  describe 'get related objects from generic file' do
 
-    subject { Hydra::Works::GenericFile::Base.new }
+  describe 'get related objects from generic file' do
+    subject { described_class.new }
 
     let(:object1) { Hydra::PCDM::Object.new }
     let(:object2) { Hydra::PCDM::Object.new }
 
     let(:generic_work1) { Hydra::Works::GenericWork::Base.new }
-    let(:generic_file1) { Hydra::Works::GenericFile::Base.new }
+    let(:generic_file1) { described_class.new }
 
     context 'with generic files' do
-      it 'should return empty array when only generic files are aggregated' do
-        expect( related_objects = subject.related_objects ).to eq []
+      it 'returns empty array when only generic files are aggregated' do
+        expect(subject.related_objects).to eq []
       end
 
-      it 'should return related objects' do
-        subject.related_objects << object2 
-        expect( related_objects = subject.related_objects ).to eq [object2]
+      it 'returns related objects' do
+        subject.related_objects << object2
+        expect(subject.related_objects).to eq [object2]
       end
 
-      it 'should return related objects of various types' do
-        subject.related_objects << generic_work1 
-        subject.related_objects << generic_file1 
+      it 'returns related objects of various types' do
+        subject.related_objects << generic_work1
+        subject.related_objects << generic_file1
         subject.related_objects << object1
         subject.save
         subject.reload
         related_objects = subject.related_objects
-        expect( related_objects.include? object1 ).to be true
-        expect( related_objects.include? generic_work1 ).to be true
-        expect( related_objects.include? generic_file1 ).to be true
-        expect( related_objects.size ).to eq 3
+        expect(related_objects.include? object1).to be true
+        expect(related_objects.include? generic_work1).to be true
+        expect(related_objects.include? generic_file1).to be true
+        expect(related_objects.size).to eq 3
       end
     end
   end
 
   describe 'remove related object from related object' do
-
-    subject { Hydra::Works::GenericFile::Base.new }
+    subject { described_class.new }
 
     let(:related_object1) { Hydra::PCDM::Object.new }
     let(:related_work2)   { Hydra::Works::GenericWork::Base.new }
-    let(:related_file3)   { Hydra::Works::GenericFile::Base.new }
+    let(:related_file3)   { described_class.new }
     let(:related_object4) { Hydra::PCDM::Object.new }
     let(:related_work5)   { Hydra::Works::GenericWork::Base.new }
 
-    let(:generic_file1) { Hydra::Works::GenericFile::Base.new }
-    let(:generic_file2) { Hydra::Works::GenericFile::Base.new }
+    let(:generic_file1) { described_class.new }
+    let(:generic_file2) { described_class.new }
 
     context 'when multiple related objects' do
       before do
-        subject.related_objects << related_object1 
+        subject.related_objects << related_object1
         subject.related_objects << related_work2
         subject.related_objects << related_file3
-        subject.related_objects << related_object4 
-        subject.related_objects << related_work5 
-        expect( related_ojects = subject.related_objects ).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
-
+        subject.related_objects << related_object4
+        subject.related_objects << related_work5
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_file3, related_object4, related_work5]
       end
 
-      it 'should remove first related object' do
-        expect( subject.related_objects.delete related_object1 ).to eq [related_object1]
-        expect( related_objects = subject.related_objects).to eq [related_work2,related_file3,related_object4,related_work5]
+      it 'removes first related object' do
+        expect(subject.related_objects.delete related_object1).to eq [related_object1]
+        expect(subject.related_objects).to eq [related_work2, related_file3, related_object4, related_work5]
       end
 
-      it 'should remove last related object' do
-        expect( subject.related_objects.delete related_work5 ).to eq [related_work5]
-        expect( related_objects = subject.related_objects ).to eq [related_object1,related_work2,related_file3,related_object4]
+      it 'removes last related object' do
+        expect(subject.related_objects.delete related_work5).to eq [related_work5]
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_file3, related_object4]
       end
 
-      it 'should remove middle related object' do
-        expect( subject.related_objects.delete related_file3  ).to eq [related_file3]
-        expect( related_objects = subject.related_objects ).to eq [related_object1,related_work2,related_object4,related_work5]
+      it 'removes middle related object' do
+        expect(subject.related_objects.delete related_file3).to eq [related_file3]
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_object4, related_work5]
       end
     end
 
-    #Assuming this context not needed because unacceptable related objects 
-    #can't be added.
-    #context 'with unacceptable related object' do
-
+    # Assuming this context not needed because unacceptable related objects
+    # can't be added.
+    # context 'with unacceptable related object' do
   end
 
-  describe "should have parent work accessors" do
+  describe 'should have parent work accessors' do
     let(:generic_work1) { Hydra::Works::GenericWork::Base.create }
     before do
       generic_work1.generic_files << generic_file1
     end
 
-    it 'should have parents' do
+    it 'has parents' do
       expect(generic_file1.parents).to eq [generic_work1]
     end
-    it 'should have a parent work' do
+    it 'has a parent work' do
       expect(generic_file1.generic_works).to eq [generic_work1]
     end
   end
-
-
 end

--- a/spec/hydra/works/models/generic_work_spec.rb
+++ b/spec/hydra/works/models/generic_work_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Hydra::Works::GenericWork do
-
   subject { Hydra::Works::GenericWork::Base.new }
 
   let(:generic_work1) { Hydra::Works::GenericWork::Base.new }
@@ -16,30 +15,30 @@ describe Hydra::Works::GenericWork do
   let(:object1) { Hydra::PCDM::Object.new }
   let(:object2) { Hydra::PCDM::Object.new }
 
-  let(:pcdm_file1)       { Hydra::PCDM::File.new }
+  let(:pcdm_file1) { Hydra::PCDM::File.new }
 
   describe '#child_generic_works=' do
-    it 'should aggregate generic_works' do
+    it 'aggregates generic_works' do
       generic_work1.child_generic_works = [generic_work2, generic_work3]
       expect(generic_work1.child_generic_works).to eq [generic_work2, generic_work3]
     end
   end
 
   describe '#generic_files=' do
-    it 'should aggregate generic_files' do
+    it 'aggregates generic_files' do
       generic_work1.generic_files = [generic_file1, generic_file2]
       expect(generic_work1.generic_files).to eq [generic_file1, generic_file2]
     end
   end
 
   describe '#generic_file_ids' do
-    it 'should list child generic_file ids' do
+    it 'lists child generic_file ids' do
       generic_work1.generic_files = [generic_file1, generic_file2]
       expect(generic_work1.generic_file_ids).to eq [generic_file1.id, generic_file2.id]
     end
   end
 
-  context "sub-class" do
+  context 'sub-class' do
     before do
       class TestWork < Hydra::Works::GenericWork::Base
       end
@@ -47,14 +46,14 @@ describe Hydra::Works::GenericWork do
 
     subject { TestWork.new(generic_files: [generic_file1]) }
 
-    it "should have many generic files" do
+    it 'has many generic files' do
       expect(subject.generic_files).to eq [generic_file1]
     end
   end
 
   describe '#contains' do
-    it 'should present as a missing method' do
-      expect{ generic_work1.contains = [pcdm_file1] }.to raise_error(NoMethodError,"works can not directly contain files.  You must add a GenericFile to the work's members and add files to that GenericFile.")
+    it 'presents as a missing method' do
+      expect { generic_work1.contains = [pcdm_file1] }.to raise_error(NoMethodError, "works can not directly contain files.  You must add a GenericFile to the work's members and add files to that GenericFile.")
     end
   end
 
@@ -73,7 +72,6 @@ describe Hydra::Works::GenericWork do
 
   describe '#child_generic_works' do
     context 'with acceptable generic_works' do
-
       context 'with generic_files and generic_works' do
         before do
           subject.generic_files << generic_file1
@@ -82,9 +80,9 @@ describe Hydra::Works::GenericWork do
           subject.child_generic_works << generic_work2
         end
 
-        it 'should add generic_work to generic_work with generic_files and generic_works' do
+        it 'adds generic_work to generic_work with generic_files and generic_works' do
           subject.child_generic_works << generic_work3
-          expect(subject.child_generic_works).to eq [generic_work1,generic_work2,generic_work3]
+          expect(subject.child_generic_works).to eq [generic_work1, generic_work2, generic_work3]
         end
       end
 
@@ -97,7 +95,7 @@ describe Hydra::Works::GenericWork do
         after { Object.send(:remove_const, :DummyIncWork) }
         let(:iwork1) { DummyIncWork.new }
 
-        it 'should accept implementing generic_work as a child' do
+        it 'accepts implementing generic_work as a child' do
           subject.child_generic_works << iwork1
           expect(subject.child_generic_works).to eq [iwork1]
         end
@@ -111,7 +109,7 @@ describe Hydra::Works::GenericWork do
         after { Object.send(:remove_const, :DummyExtWork) }
         let(:ework1) { DummyExtWork.new }
 
-        it 'should accept extending generic_work as a child' do
+        it 'accepts extending generic_work as a child' do
           subject.child_generic_works << ework1
           expect(subject.child_generic_works).to eq [ework1]
         end
@@ -127,50 +125,49 @@ describe Hydra::Works::GenericWork do
         @pcdm_collection101   = Hydra::PCDM::Collection.new
         @pcdm_object101       = Hydra::PCDM::Object.new
         @pcdm_file101         = Hydra::PCDM::File.new
-        @non_PCDM_object      = "I'm not a PCDM object"
+        @non_pcdm_object      = "I'm not a PCDM object"
         @af_base_object       = ActiveFedora::Base.new
       end
 
       context 'that are unacceptable child generic works' do
-
         let(:error_type1)    { ArgumentError }
         let(:error_message1) { /Hydra::Works::(GenericFile::Base|Collection) with ID:  was expected to works_generic_work\?, but it was false/ }
         let(:error_type2)    { NoMethodError }
         let(:error_message2) { /undefined method `works_generic_work\?' for .*/ }
 
-        it 'should NOT aggregate Hydra::Works::Collection in generic works aggregation' do
-          expect{ subject.child_generic_works << @works_collection101 }.to raise_error(error_type1,error_message1)
+        it 'does not aggregate Hydra::Works::Collection in generic works aggregation' do
+          expect { subject.child_generic_works << @works_collection101 }.to raise_error(error_type1, error_message1)
         end
 
-        it 'should NOT aggregate Hydra::Works::GenericFile in generic works aggregation' do
-          expect{ subject.child_generic_works << @generic_file101 }.to raise_error(error_type1,error_message1)
+        it 'does not aggregate Hydra::Works::GenericFile in generic works aggregation' do
+          expect { subject.child_generic_works << @generic_file101 }.to raise_error(error_type1, error_message1)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Collections in generic works aggregation' do
-          expect{ subject.child_generic_works << @pcdm_collection101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Collections in generic works aggregation' do
+          expect { subject.child_generic_works << @pcdm_collection101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Objects in generic works aggregation' do
-          expect{ subject.child_generic_works << @pcdm_object101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Objects in generic works aggregation' do
+          expect { subject.child_generic_works << @pcdm_object101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Files in generic works aggregation' do
-          expect{ subject.child_generic_works << @pcdm_file101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Files in generic works aggregation' do
+          expect { subject.child_generic_works << @pcdm_file101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate non-PCDM objects in generic works aggregation' do
-          expect{ subject.child_generic_works << @non_PCDM_object }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate non-PCDM objects in generic works aggregation' do
+          expect { subject.child_generic_works << @non_pcdm_object }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate AF::Base objects in generic works aggregation' do
-          expect{ subject.child_generic_works << @af_base_object }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate AF::Base objects in generic works aggregation' do
+          expect { subject.child_generic_works << @af_base_object }.to raise_error(error_type2, error_message2)
         end
       end
     end
   end
 
   describe '#generic_files <<' do
-    it 'should return empty array when only generic_files are aggregated' do
+    it 'returns empty array when only generic_files are aggregated' do
       subject.generic_files << generic_file1
       subject.generic_files << generic_file2
       expect(subject.child_generic_works).to eq []
@@ -184,10 +181,10 @@ describe Hydra::Works::GenericWork do
         subject.child_generic_works << generic_work2
       end
 
-      it 'should only return generic_works' do
-        expect(subject.child_generic_works).to eq [generic_work1,generic_work2]
+      it 'returns only generic_works' do
+        expect(subject.child_generic_works).to eq [generic_work1, generic_work2]
       end
-   end
+    end
   end
 
   describe '#child_generic_works.delete' do
@@ -200,25 +197,25 @@ describe Hydra::Works::GenericWork do
         subject.child_generic_works << generic_work4
         subject.generic_files << generic_file1
         subject.child_generic_works << generic_work5
-        expect(subject.child_generic_works).to eq [generic_work1,generic_work2,generic_work3,generic_work4,generic_work5]
+        expect(subject.child_generic_works).to eq [generic_work1, generic_work2, generic_work3, generic_work4, generic_work5]
       end
 
-      it 'should remove first collection' do
+      it 'removes first collection' do
         expect(subject.child_generic_works.delete generic_work1).to eq [generic_work1]
-        expect(subject.child_generic_works).to eq [generic_work2,generic_work3,generic_work4,generic_work5]
-        expect(subject.generic_files).to eq [generic_file2,generic_file1]
+        expect(subject.child_generic_works).to eq [generic_work2, generic_work3, generic_work4, generic_work5]
+        expect(subject.generic_files).to eq [generic_file2, generic_file1]
       end
 
-      it 'should remove last collection' do
+      it 'removes last collection' do
         expect(subject.child_generic_works.delete generic_work5).to eq [generic_work5]
-        expect(subject.child_generic_works).to eq [generic_work1,generic_work2,generic_work3,generic_work4]
-        expect(subject.generic_files).to eq [generic_file2,generic_file1]
+        expect(subject.child_generic_works).to eq [generic_work1, generic_work2, generic_work3, generic_work4]
+        expect(subject.generic_files).to eq [generic_file2, generic_file1]
       end
 
-      it 'should remove middle collection' do
+      it 'removes middle collection' do
         expect(subject.child_generic_works.delete generic_work3).to eq [generic_work3]
-        expect(subject.child_generic_works).to eq [generic_work1,generic_work2,generic_work4,generic_work5]
-        expect(subject.generic_files).to eq [generic_file2,generic_file1]
+        expect(subject.child_generic_works).to eq [generic_work1, generic_work2, generic_work4, generic_work5]
+        expect(subject.generic_files).to eq [generic_file2, generic_file1]
       end
     end
   end
@@ -234,9 +231,9 @@ describe Hydra::Works::GenericWork do
           subject.child_generic_works << generic_work2
         end
 
-        it 'should add generic_file to generic_work with generic_files and generic_works' do
+        it 'adds generic_file to generic_work with generic_files and generic_works' do
           subject.generic_files << generic_file3
-          expect(subject.generic_files).to eq [generic_file1,generic_file2,generic_file3]
+          expect(subject.generic_files).to eq [generic_file1, generic_file2, generic_file3]
         end
       end
 
@@ -249,11 +246,10 @@ describe Hydra::Works::GenericWork do
         after { Object.send(:remove_const, :DummyIncFile) }
         let(:ifile1) { DummyIncFile.new }
 
-        it 'should accept implementing generic_file as a child' do
+        it 'accepts implementing generic_file as a child' do
           subject.generic_files << ifile1
           expect(subject.generic_files).to eq [ifile1]
         end
-
       end
 
       describe 'aggregates generic_files that extend Hydra::Works::GenericFile::Base' do
@@ -264,7 +260,7 @@ describe Hydra::Works::GenericWork do
         after { Object.send(:remove_const, :DummyExtFile) }
         let(:efile1) { DummyExtFile.new }
 
-        it 'should accept extending generic_file as a child' do
+        it 'accepts extending generic_file as a child' do
           subject.generic_files << efile1
           expect(subject.generic_files).to eq [efile1]
         end
@@ -281,54 +277,53 @@ describe Hydra::Works::GenericWork do
         @pcdm_collection101   = Hydra::PCDM::Collection.new
         @pcdm_object101       = Hydra::PCDM::Object.new
         @pcdm_file101         = Hydra::PCDM::File.new
-        @non_PCDM_object      = "I'm not a PCDM object"
+        @non_pcdm_object      = "I'm not a PCDM object"
         @af_base_object       = ActiveFedora::Base.new
       end
 
       context 'that are unacceptable child generic files' do
-
         let(:error_type1)    { ArgumentError }
         let(:error_message1) { /Hydra::Works::(GenericWork::Base|Collection) with ID:  was expected to works_generic_file\?, but it was false/ }
         let(:error_type2)    { NoMethodError }
         let(:error_message2) { /undefined method `works_generic_file\?' for .*/ }
 
-        it 'should NOT aggregate Hydra::Works::Collection in generic files aggregation' do
-          expect{ subject.generic_files << @works_collection101 }.to raise_error(error_type1,error_message1)
+        it 'does not aggregate Hydra::Works::Collection in generic files aggregation' do
+          expect { subject.generic_files << @works_collection101 }.to raise_error(error_type1, error_message1)
         end
 
-        it 'should NOT aggregate Hydra::Works::GenericWork in generic files aggregation' do
-          expect{ subject.generic_files << @generic_work101 }.to raise_error(error_type1,error_message1)
+        it 'does not aggregate Hydra::Works::GenericWork in generic files aggregation' do
+          expect { subject.generic_files << @generic_work101 }.to raise_error(error_type1, error_message1)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Collections in generic files aggregation' do
-          expect{ subject.generic_files << @pcdm_collection101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Collections in generic files aggregation' do
+          expect { subject.generic_files << @pcdm_collection101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Objects in generic files aggregation' do
-          expect{ subject.generic_files << @pcdm_object101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Objects in generic files aggregation' do
+          expect { subject.generic_files << @pcdm_object101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate Hydra::PCDM::Files in generic files aggregation' do
-          expect{ subject.generic_files << @pcdm_file101 }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate Hydra::PCDM::Files in generic files aggregation' do
+          expect { subject.generic_files << @pcdm_file101 }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate non-PCDM objects in generic files aggregation' do
-          expect{ subject.generic_files << @non_PCDM_object }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate non-PCDM objects in generic files aggregation' do
+          expect { subject.generic_files << @non_pcdm_object }.to raise_error(error_type2, error_message2)
         end
 
-        it 'should NOT aggregate AF::Base objects in generic files aggregation' do
-          expect{ subject.generic_files << @af_base_object }.to raise_error(error_type2,error_message2)
+        it 'does not aggregate AF::Base objects in generic files aggregation' do
+          expect { subject.generic_files << @af_base_object }.to raise_error(error_type2, error_message2)
         end
       end
     end
   end
 
-  context "move generic file" do 
-    before do 
+  context 'move generic file' do
+    before do
       subject.generic_files << generic_file1
       subject.generic_files << generic_file2
     end
-    it "moves file from one work to another" do
+    it 'moves file from one work to another' do
       expect(subject.generic_files).to eq([generic_file1, generic_file2])
       expect(generic_work1.generic_files).to eq([])
       generic_work1.generic_files << subject.generic_files.delete(generic_file1)
@@ -338,7 +333,7 @@ describe Hydra::Works::GenericWork do
   end
 
   describe '#generic_files' do
-    it 'should return empty array when only generic_works are aggregated' do
+    it 'returns empty array when only generic_works are aggregated' do
       subject.child_generic_works << generic_work1
       subject.child_generic_works << generic_work2
       expect(subject.generic_files).to eq []
@@ -352,10 +347,10 @@ describe Hydra::Works::GenericWork do
         subject.child_generic_works << generic_work2
       end
 
-      it 'should only return generic_files' do
-        expect(subject.generic_files).to eq [generic_file1,generic_file2]
+      it 'returns only generic_files' do
+        expect(subject.generic_files).to eq [generic_file1, generic_file2]
       end
-   end
+    end
   end
 
   describe '#generic_files.delete' do
@@ -371,34 +366,32 @@ describe Hydra::Works::GenericWork do
         subject.generic_files << generic_file4
         subject.child_generic_works << generic_work1
         subject.generic_files << generic_file5
-        expect(subject.generic_files).to eq [generic_file1,generic_file2,generic_file3,generic_file4,generic_file5]
+        expect(subject.generic_files).to eq [generic_file1, generic_file2, generic_file3, generic_file4, generic_file5]
       end
 
-      it 'should remove first collection' do
+      it 'removes first collection' do
         expect(subject.generic_files.delete generic_file1).to eq [generic_file1]
-        expect(subject.generic_files).to eq [generic_file2,generic_file3,generic_file4,generic_file5]
-        expect(subject.child_generic_works).to eq [generic_work2,generic_work1]
+        expect(subject.generic_files).to eq [generic_file2, generic_file3, generic_file4, generic_file5]
+        expect(subject.child_generic_works).to eq [generic_work2, generic_work1]
       end
 
-      it 'should remove last collection' do
+      it 'removes last collection' do
         expect(subject.generic_files.delete generic_file5).to eq [generic_file5]
-        expect(subject.generic_files).to eq [generic_file1,generic_file2,generic_file3,generic_file4]
-        expect(subject.child_generic_works).to eq [generic_work2,generic_work1]
+        expect(subject.generic_files).to eq [generic_file1, generic_file2, generic_file3, generic_file4]
+        expect(subject.child_generic_works).to eq [generic_work2, generic_work1]
       end
 
-      it 'should remove middle collection' do
+      it 'removes middle collection' do
         expect(subject.generic_files.delete generic_file3).to eq [generic_file3]
-        expect(subject.generic_files).to eq [generic_file1,generic_file2,generic_file4,generic_file5]
-        expect(subject.child_generic_works).to eq [generic_work2,generic_work1]
+        expect(subject.generic_files).to eq [generic_file1, generic_file2, generic_file4, generic_file5]
+        expect(subject.child_generic_works).to eq [generic_work2, generic_work1]
       end
     end
   end
 
   describe '#related_objects' do
-
     context 'with acceptable related objects' do
-
-      it 'should add various types of related objects to generic_work' do
+      it 'adds various types of related objects to generic_work' do
         subject.related_objects << generic_work1
         subject.related_objects << generic_file1
         subject.related_objects << object1
@@ -419,7 +412,7 @@ describe Hydra::Works::GenericWork do
           subject.related_objects << object1
         end
 
-        it 'should add a related object to generic_work with generic_works and generic_files' do
+        it 'adds a related object to generic_work with generic_works and generic_files' do
           subject.related_objects << object2
           subject.save
           subject.reload
@@ -439,37 +432,37 @@ describe Hydra::Works::GenericWork do
 
       let(:error_message) { 'child_related_object must be a pcdm object' }
 
-      it 'should NOT aggregate Hydra::Works::Collection in related objects aggregation' do
-        expect{ subject.related_objects << collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::Works::Collection:.*> is not a PCDM object./)
+      it 'does not aggregate Hydra::Works::Collection in related objects aggregation' do
+        expect { subject.related_objects << collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::Works::Collection:.*> is not a PCDM object./)
       end
 
-      it 'should NOT aggregate Hydra::PCDM::Collections in related objects aggregation' do
-        expect{ subject.related_objects << pcdm_collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::PCDM::Collection:.*> is not a PCDM object./)
+      it 'does not aggregate Hydra::PCDM::Collections in related objects aggregation' do
+        expect { subject.related_objects << pcdm_collection1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /Hydra::PCDM::Collection:.*> is not a PCDM object./)
       end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in related objects aggregation' do
-        expect{ subject.related_objects << pcdm_file1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got Hydra::PCDM::File.*/)
+      it 'does not aggregate Hydra::PCDM::Files in related objects aggregation' do
+        expect { subject.related_objects << pcdm_file1 }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got Hydra::PCDM::File.*/)
       end
 
-      it 'should NOT aggregate non-PCDM objects in related objects aggregation' do
-        expect{ subject.related_objects << non_PCDM_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got String.*/)
+      it 'does not aggregate non-PCDM objects in related objects aggregation' do
+        expect { subject.related_objects << non_PCDM_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base.* expected, got String.*/)
       end
 
-      it 'should NOT aggregate AF::Base objects in related objects aggregation' do
-        expect{ subject.related_objects << af_base_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base:.*> is not a PCDM object./)
+      it 'does not aggregate AF::Base objects in related objects aggregation' do
+        expect { subject.related_objects << af_base_object }.to raise_error(ActiveFedora::AssociationTypeMismatch, /ActiveFedora::Base:.*> is not a PCDM object./)
       end
     end
 
     context 'with invalid bahaviors' do
-      it 'should NOT allow related objects to repeat' do
+      it 'does not allow related objects to repeat' do
         skip 'skipping this test because issue pcdm#92 needs to be addressed' do
-        subject.related_objects << object1
-        subject.related_objects << object2
-        subject.related_objects << object1
-        expect(subject.related_objects.include? object1).to be true
-        expect(subject.related_objects.include? object2).to be true
-        expect(subject.related_objects.size).to eq 2
-      end
+          subject.related_objects << object1
+          subject.related_objects << object2
+          subject.related_objects << object1
+          expect(subject.related_objects.include? object1).to be true
+          expect(subject.related_objects.include? object2).to be true
+          expect(subject.related_objects.size).to eq 2
+        end
       end
     end
   end
@@ -482,23 +475,23 @@ describe Hydra::Works::GenericWork do
         subject.generic_files << generic_file1
       end
 
-      it 'should return empty array when only generic files and generic works are aggregated' do
+      it 'returns empty array when only generic files and generic works are aggregated' do
         expect(subject.related_objects).to eq []
       end
 
-      it 'should only return related objects' do
+      it 'returns only related objects' do
         subject.related_objects << object2
         expect(subject.related_objects).to eq [object2]
       end
 
-      it 'should return related objects of various types' do
+      it 'returns related objects of various types' do
         subject.related_objects << generic_work2
         subject.related_objects << generic_file1
         subject.related_objects << object1
-        expect(subject.related_objects).to eq [generic_work2,generic_file1,object1]
+        expect(subject.related_objects).to eq [generic_work2, generic_file1, object1]
         expect(subject.related_objects.size).to eq 3
       end
-   end
+    end
   end
 
   describe '#related_objects.delete' do
@@ -517,33 +510,33 @@ describe Hydra::Works::GenericWork do
         subject.related_objects << related_object4
         subject.child_generic_works << generic_work1
         subject.related_objects << related_work5
-        expect(subject.related_objects).to eq [related_object1,related_work2,related_file3,related_object4,related_work5]
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_file3, related_object4, related_work5]
       end
 
-      it 'should remove first related object' do
+      it 'removes first related object' do
         expect(subject.related_objects.delete related_object1).to eq [related_object1]
-        expect(subject.related_objects).to eq [related_work2,related_file3,related_object4,related_work5]
-        expect(subject.child_generic_works).to eq [generic_work2,generic_work1]
+        expect(subject.related_objects).to eq [related_work2, related_file3, related_object4, related_work5]
+        expect(subject.child_generic_works).to eq [generic_work2, generic_work1]
         expect(subject.generic_files).to eq [generic_file1]
       end
 
-      it 'should remove last related object' do
+      it 'removes last related object' do
         expect(subject.related_objects.delete related_work5).to eq [related_work5]
-        expect(subject.related_objects).to eq [related_object1,related_work2,related_file3,related_object4]
-        expect(subject.child_generic_works).to eq [generic_work2,generic_work1]
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_file3, related_object4]
+        expect(subject.child_generic_works).to eq [generic_work2, generic_work1]
         expect(subject.generic_files).to eq [generic_file1]
       end
 
-      it 'should remove middle related object' do
+      it 'removes middle related object' do
         expect(subject.related_objects.delete related_file3).to eq [related_file3]
-        expect(subject.related_objects).to eq [related_object1,related_work2,related_object4,related_work5]
-        expect(subject.child_generic_works).to eq [generic_work2,generic_work1]
+        expect(subject.related_objects).to eq [related_object1, related_work2, related_object4, related_work5]
+        expect(subject.child_generic_works).to eq [generic_work2, generic_work1]
         expect(subject.generic_files).to eq [generic_file1]
       end
     end
   end
 
-  describe "should have parent work and collection accessors" do
+  describe 'should have parent work and collection accessors' do
     let(:collection1) { Hydra::Works::Collection.new }
     before do
       collection1.child_generic_works << generic_work2
@@ -553,13 +546,13 @@ describe Hydra::Works::GenericWork do
       generic_work2.save
     end
 
-    it 'should have parents' do
-      expect(generic_work2.parents).to eq [collection1,generic_work1]
+    it 'has parents' do
+      expect(generic_work2.parents).to eq [collection1, generic_work1]
     end
-    it 'should have a parent collection' do
+    it 'has a parent collection' do
       expect(generic_work2.parent_collections).to eq [collection1]
     end
-    it 'should have a parent generic_work' do
+    it 'has a parent generic_work' do
       expect(generic_work2.parent_generic_works).to eq [generic_work1]
     end
   end

--- a/spec/hydra/works/services/generic_file/add_file_to_generic_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/add_file_to_generic_file_spec.rb
@@ -1,110 +1,108 @@
 require 'spec_helper'
 
 describe Hydra::Works::AddFileToGenericFile do
-
   let(:generic_file)        { Hydra::Works::GenericFile::Base.new }
-  let(:filename)            { "sample-file.pdf" }
-  let(:filename2)           { "updated-file.txt" }
-  let(:original_name)       { "original-name.pdf" }
+  let(:filename)            { 'sample-file.pdf' }
+  let(:filename2)           { 'updated-file.txt' }
+  let(:original_name)       { 'original-name.pdf' }
   let(:file)                { File.open(File.join(fixture_path, filename)) }
   let(:file2)               { File.open(File.join(fixture_path, filename2)) }
-  let(:type)                { ::RDF::URI("http://pcdm.org/use#ExtractedText") }
+  let(:type)                { ::RDF::URI('http://pcdm.org/use#ExtractedText') }
   let(:update_existing)     { true }
-  let(:mime_type)           { "application/pdf" }
+  let(:mime_type)           { 'application/pdf' }
 
-  context "when generic_file is not persisted" do
-    let(:generic_file)        { Hydra::Works::GenericFile::Base.new }
-    it "saves generic_file" do
+  context 'when generic_file is not persisted' do
+    let(:generic_file) { Hydra::Works::GenericFile::Base.new }
+    it 'saves generic_file' do
       described_class.call(generic_file, file, type)
       expect(generic_file.persisted?).to be true
     end
   end
 
-  context "when generic_file is not valid" do
+  context 'when generic_file is not valid' do
     before do
       generic_file.save
       allow(generic_file).to receive(:valid?).and_return(false)
     end
-    it "returns false" do
-      expect( described_class.call(generic_file, file, type) ).to be false
+    it 'returns false' do
+      expect(described_class.call(generic_file, file, type)).to be false
     end
   end
 
-  context "file responds to :mime_type and :original_name" do
+  context 'file responds to :mime_type and :original_name' do
     before do
-      allow(file).to         receive(:mime_type).and_return(mime_type)
-      allow(file).to         receive(:original_name).and_return(original_name)
+      allow(file).to receive(:mime_type).and_return(mime_type)
+      allow(file).to receive(:original_name).and_return(original_name)
       described_class.call(generic_file, file, type)
     end
     subject { generic_file.filter_files_by_type(type).first }
-    it "uses the mime_type and original_name methods" do
+    it 'uses the mime_type and original_name methods' do
       expect(subject.mime_type).to eq(mime_type)
       expect(subject.original_name).to eq(original_name)
     end
   end
 
-  context "file responds to :path but not to :mime_type nor :original_name" do
-    it "defaults to Hydra::PCDM for mimetype and ::File for basename." do
-    expect(Hydra::PCDM::GetMimeTypeForFile).to receive(:call).with(file.path)
-    expect(::File).to receive(:basename).with(file.path)
-    described_class.call(generic_file, file, type)
+  context 'file responds to :path but not to :mime_type nor :original_name' do
+    it 'defaults to Hydra::PCDM for mimetype and ::File for basename.' do
+      expect(Hydra::PCDM::GetMimeTypeForFile).to receive(:call).with(file.path)
+      expect(::File).to receive(:basename).with(file.path)
+      described_class.call(generic_file, file, type)
     end
   end
 
-  it "adds the given file and applies the specified type to it" do
+  it 'adds the given file and applies the specified type to it' do
     described_class.call(generic_file, file, type, update_existing: update_existing)
-    expect(generic_file.filter_files_by_type(type).first.content).to start_with("%PDF-1.3")
+    expect(generic_file.filter_files_by_type(type).first.content).to start_with('%PDF-1.3')
   end
 
-  context "when :type is the name of an association" do
+  context 'when :type is the name of an association' do
     let(:type)  { :extracted_text }
     before do
       described_class.call(generic_file, file, type)
     end
     it "builds and uses the association's target" do
-      expect(generic_file.extracted_text.content).to start_with("%PDF-1.3")
+      expect(generic_file.extracted_text.content).to start_with('%PDF-1.3')
     end
   end
 
-  context "when :versioning => true" do
+  context 'when :versioning => true' do
     let(:type)        { :original_file }
     let(:versioning)  { true }
     subject     { generic_file }
-    it "updates the file and creates a version" do
+    it 'updates the file and creates a version' do
       described_class.call(generic_file, file, type, versioning: versioning)
       expect(subject.original_file.versions.all.count).to eq(1)
-      expect(subject.original_file.content).to start_with("%PDF-1.3")
+      expect(subject.original_file.content).to start_with('%PDF-1.3')
     end
-    context "and there are already versions" do
+    context 'and there are already versions' do
       before do
         described_class.call(generic_file, file, type, versioning: versioning)
         described_class.call(generic_file, file2, type, versioning: versioning)
       end
-      it "adds to the version history" do
+      it 'adds to the version history' do
         expect(subject.original_file.versions.all.count).to eq(2)
         expect(subject.original_file.content).to eq("some updated content\n")
       end
     end
   end
 
-  context "when :versioning => false" do
+  context 'when :versioning => false' do
     let(:type)        { :original_file }
     let(:versioning)  { false }
     before do
       described_class.call(generic_file, file, type, versioning: versioning)
     end
-    subject     { generic_file }
-    it "skips creating versions" do
+    subject { generic_file }
+    it 'skips creating versions' do
       expect(subject.original_file.versions.all.count).to eq(0)
-      expect(subject.original_file.content).to start_with("%PDF-1.3")
+      expect(subject.original_file.content).to start_with('%PDF-1.3')
     end
   end
 
-  context "type_to_uri" do
+  context 'type_to_uri' do
     subject { Hydra::Works::AddFileToGenericFile::Updater.allocate }
-    it "converts URI strings to RDF::URI" do
-      expect(subject.send(:type_to_uri, "http://example.com/CustomURI" )).to eq(::RDF::URI("http://example.com/CustomURI"))
+    it 'converts URI strings to RDF::URI' do
+      expect(subject.send(:type_to_uri, 'http://example.com/CustomURI')).to eq(::RDF::URI('http://example.com/CustomURI'))
     end
   end
-
 end

--- a/spec/hydra/works/services/generic_file/generate/thumbnail_spec.rb
+++ b/spec/hydra/works/services/generic_file/generate/thumbnail_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
 
 describe Hydra::Works::GenerateThumbnail do
-
-  context "when the object has no original file" do
-    let(:error_message) { "object has no content at original_file from which to generate a thumbnail" }
-    let(:object) { double("object", original_file: nil ) }
-    it "raises an error" do
-      expect(lambda{ described_class.call(object) }).to raise_error(ArgumentError, error_message)
+  context 'when the object has no original file' do
+    let(:error_message) { 'object has no content at original_file from which to generate a thumbnail' }
+    let(:object) { double('object', original_file: nil) }
+    it 'raises an error' do
+      expect(-> { described_class.call(object) }).to raise_error(ArgumentError, error_message)
     end
   end
 
-  context "when the object has no content at specified location" do
-    let(:error_message) { "object has no content at my_location from which to generate a thumbnail" }
-    let(:object) { double("object", my_location: nil ) }
-    it "raises an error" do
-      expect(lambda{ described_class.call(object, content: :my_location) }).to raise_error(ArgumentError, error_message)
+  context 'when the object has no content at specified location' do
+    let(:error_message) { 'object has no content at my_location from which to generate a thumbnail' }
+    let(:object) { double('object', my_location: nil) }
+    it 'raises an error' do
+      expect(-> { described_class.call(object, content: :my_location) }).to raise_error(ArgumentError, error_message)
     end
   end
-
 end

--- a/spec/hydra/works/services/generic_file/upload_file_spec.rb
+++ b/spec/hydra/works/services/generic_file/upload_file_spec.rb
@@ -1,64 +1,63 @@
 require 'spec_helper'
 
 describe Hydra::Works::UploadFileToGenericFile do
-
   let(:generic_work)        { Hydra::Works::GenericWork::Base.new }
   let(:generic_file)        { Hydra::Works::GenericFile::Base.new }
-  let(:file)                { File.open(File.join(fixture_path, "sample-file.pdf")) }
-  let(:updated_file)        { File.open(File.join(fixture_path, "updated-file.txt")) }
-  let(:mime_type)           { "application/pdf" }
-  let(:original_name)       { "my_original.pdf" }
-  let(:updated_mime_type)   { "text/plain" }
-  let(:updated_name)        { "my_updated.txt" }
+  let(:file)                { File.open(File.join(fixture_path, 'sample-file.pdf')) }
+  let(:updated_file)        { File.open(File.join(fixture_path, 'updated-file.txt')) }
+  let(:mime_type)           { 'application/pdf' }
+  let(:original_name)       { 'my_original.pdf' }
+  let(:updated_mime_type)   { 'text/plain' }
+  let(:updated_name)        { 'my_updated.txt' }
   let(:additional_services) { [Hydra::Works::GenerateThumbnail] }
 
-  context "when you provide mime_type and original_name, etc" do
-    it "uses the provided values" do
-      expect(Hydra::Works::AddFileToGenericFile).to receive(:call).with(generic_file, file, :original_file, update_existing: true, versioning: true )
-      described_class.call(generic_file, file )
+  context 'when you provide mime_type and original_name, etc' do
+    it 'uses the provided values' do
+      expect(Hydra::Works::AddFileToGenericFile).to receive(:call).with(generic_file, file, :original_file, update_existing: true, versioning: true)
+      described_class.call(generic_file, file)
     end
   end
 
   # Duplicate test from add_file_spec
-  context "without a proper generic file" do
-    let(:error_message) { "supplied object must be a generic file" }
-    it "raises an error" do
-      expect( lambda { described_class.call(generic_work, file) }).to raise_error(ArgumentError, error_message)
+  context 'without a proper generic file' do
+    let(:error_message) { 'supplied object must be a generic file' }
+    it 'raises an error' do
+      expect(-> { described_class.call(generic_work, file) }).to raise_error(ArgumentError, error_message)
     end
   end
 
   # Duplicate test from add_file_spec
-  context "without file that responds to read." do
-    let(:error_message) { "supplied file must respond to read" }
-    it "raises an error" do
-      expect( lambda { described_class.call(generic_file, ["this does not respond to read."]) }).to raise_error(ArgumentError, error_message)
+  context 'without file that responds to read.' do
+    let(:error_message) { 'supplied file must respond to read' }
+    it 'raises an error' do
+      expect(-> { described_class.call(generic_file, ['this does not respond to read.']) }).to raise_error(ArgumentError, error_message)
     end
   end
 
-  context "with an empty generic file" do
-    before do 
-      allow(file).to         receive(:mime_type).and_return(mime_type)
-      allow(file).to         receive(:original_name).and_return(original_name)
-      described_class.call(generic_file, file, additional_services: additional_services) 
+  context 'with an empty generic file' do
+    before do
+      allow(file).to receive(:mime_type).and_return(mime_type)
+      allow(file).to receive(:original_name).and_return(original_name)
+      described_class.call(generic_file, file, additional_services: additional_services)
     end
 
-    describe "the uploaded file" do
+    describe 'the uploaded file' do
       subject { generic_file.original_file }
-      it "has content" do
-        expect(subject.content).to start_with("%PDF-1.3")
+      it 'has content' do
+        expect(subject.content).to start_with('%PDF-1.3')
       end
-      it "has a mime type" do
+      it 'has a mime type' do
         expect(subject.mime_type).to eql mime_type
       end
-      it "has a name" do
+      it 'has a name' do
         expect(subject.original_name).to eql original_name
       end
     end
 
     describe "the generic file's generated files" do
       subject { generic_file }
-      it "has content and generated files" do
-        expect(subject.original_file.content).to start_with("%PDF-1.3")
+      it 'has content and generated files' do
+        expect(subject.original_file.content).to start_with('%PDF-1.3')
         expect(subject.original_file.mime_type).to eql mime_type
         expect(subject.original_file.original_name).to eql original_name
         expect(subject.thumbnail.content).not_to be_nil
@@ -66,34 +65,32 @@ describe Hydra::Works::UploadFileToGenericFile do
     end
   end
 
-  context "when updating an existing file" do
+  context 'when updating an existing file' do
     let(:additional_services) { [] }
 
     before do
-      allow(file).to         receive(:mime_type).and_return(mime_type)
-      allow(file).to         receive(:original_name).and_return(original_name)
-      allow(updated_file).to         receive(:mime_type).and_return(updated_mime_type)
-      allow(updated_file).to         receive(:original_name).and_return(updated_name)
+      allow(file).to receive(:mime_type).and_return(mime_type)
+      allow(file).to receive(:original_name).and_return(original_name)
+      allow(updated_file).to receive(:mime_type).and_return(updated_mime_type)
+      allow(updated_file).to receive(:original_name).and_return(updated_name)
 
       described_class.call(generic_file, file, additional_services: additional_services)
       described_class.call(generic_file, updated_file, additional_services: additional_services, update_existing: true)
     end
 
-    describe "the new file" do
+    describe 'the new file' do
       subject { generic_file.original_file }
-      it "has updated content" do
+      it 'has updated content' do
         updated_file.rewind
         expect(subject.content).to eql updated_file.read
       end
-      it "has an updated name" do
+      it 'has an updated name' do
         expect(subject.original_name).to eql updated_name
       end
-      it "has a updated mime type" do
+      it 'has a updated mime type' do
         expect(subject.mime_type).to eql updated_mime_type
         expect(subject.versions.all.count).to eql 2
       end
     end
   end
-
 end
-  

--- a/spec/hydra/works/services/persist_derivatives_spec.rb
+++ b/spec/hydra/works/services/persist_derivatives_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Hydra::Works::PersistDerivative do
-
   describe 'thumbnail generation' do
     before do
       file = File.open(File.join(fixture_path, file_name), 'r')
@@ -37,7 +36,7 @@ describe Hydra::Works::PersistDerivative do
 
       it 'uses PersistDerivative service to generate a thumbnail derivative' do
         generic_file.create_derivatives
-        expect(Hydra::Derivatives.output_file_service).to eq(Hydra::Works::PersistDerivative)
+        expect(Hydra::Derivatives.output_file_service).to eq(described_class)
         expect(generic_file.thumbnail).to have_content
         expect(generic_file.thumbnail.mime_type).to eq('image/jpeg')
       end

--- a/spec/hydra/works_spec.rb
+++ b/spec/hydra/works_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Hydra::Works do
-
   let(:works_coll)   { Hydra::Works::Collection.new }
   let(:works_gwork)  { Hydra::Works::GenericWork::Base.new }
   let(:works_gfile)  { Hydra::Works::GenericFile::Base.new }
@@ -11,139 +10,136 @@ describe Hydra::Works do
   let(:pcdm_file)  { Hydra::PCDM::File.new }
 
   describe 'Validations' do
-
-    describe "#works_collection?" do
-      it "should return true for a works collection" do
-        expect( works_coll.works_collection? ).to be true
+    describe '#works_collection?' do
+      it 'returns true for a works collection' do
+        expect(works_coll.works_collection?).to be true
       end
 
-      it "should return false for a works generic work" do
-        expect( works_gwork.works_collection? ).to be false
+      it 'returns false for a works generic work' do
+        expect(works_gwork.works_collection?).to be false
       end
 
-      it "should return false for a works generic file" do
-        expect( works_gfile.works_collection? ).to be false
+      it 'returns false for a works generic file' do
+        expect(works_gfile.works_collection?).to be false
       end
 
-      it "should return that method is not available for pcdm a collection" do
+      it 'returns that method is not available for pcdm a collection' do
         expect(pcdm_coll).not_to respond_to(:works_collection?)
       end
 
-      it "should return that method is not available for a pcdm object" do
+      it 'returns that method is not available for a pcdm object' do
         expect(pcdm_obj).not_to respond_to(:works_collection?)
       end
 
-      it "should return that method is not available for a pcdm file" do
+      it 'returns that method is not available for a pcdm file' do
         expect(pcdm_file).not_to respond_to(:works_collection?)
       end
     end
 
-    describe "#works_generic_work?" do
-      it "should return false for a works collection" do
-        expect( works_coll.works_generic_work? ).to be false
+    describe '#works_generic_work?' do
+      it 'returns false for a works collection' do
+        expect(works_coll.works_generic_work?).to be false
       end
 
-      it "should return true for a works generic work" do
-        expect( works_gwork.works_generic_work? ).to be true
+      it 'returns true for a works generic work' do
+        expect(works_gwork.works_generic_work?).to be true
       end
 
-      it "should return false for a works generic file" do
-        expect( works_gfile.works_generic_work? ).to be false
+      it 'returns false for a works generic file' do
+        expect(works_gfile.works_generic_work?).to be false
       end
 
-      it "should return that method is not available for a pcdm collection" do
+      it 'returns that method is not available for a pcdm collection' do
         expect(pcdm_coll).not_to respond_to(:works_generic_work?)
       end
 
-      it "should return that method is not available for a pcdm object" do
+      it 'returns that method is not available for a pcdm object' do
         expect(pcdm_obj).not_to respond_to(:works_generic_work?)
       end
 
-      it "should return that method is not available for a pcdm file" do
+      it 'returns that method is not available for a pcdm file' do
         expect(pcdm_file).not_to respond_to(:works_generic_work?)
       end
     end
 
-    describe "#works_generic_file?" do
-      it "should return false for a works collection" do
-        expect( works_coll.works_generic_file? ).to be false
+    describe '#works_generic_file?' do
+      it 'returns false for a works collection' do
+        expect(works_coll.works_generic_file?).to be false
       end
 
-      it "should return false for a works generic work" do
-        expect( works_gwork.works_generic_file? ).to be false
+      it 'returns false for a works generic work' do
+        expect(works_gwork.works_generic_file?).to be false
       end
 
-      it "should return true for a works generic file" do
-        expect( works_gfile.works_generic_file? ).to be true
+      it 'returns true for a works generic file' do
+        expect(works_gfile.works_generic_file?).to be true
       end
 
-      it "should return that method is not available for a pcdm collection" do
+      it 'returns that method is not available for a pcdm collection' do
         expect(pcdm_coll).not_to respond_to(:works_generic_file?)
       end
 
-      it "should return that method is not available for a pcdm object" do
+      it 'returns that method is not available for a pcdm object' do
         expect(pcdm_obj).not_to respond_to(:works_generic_file?)
       end
 
-      it "should return that method is not available for a pcdm file" do
+      it 'returns that method is not available for a pcdm file' do
         expect(pcdm_file).not_to respond_to(:works_generic_file?)
       end
     end
   end
 
-  describe "Hydra::PCDM" do
-    describe "#collection?" do
-      it "should return true for a works collection" do
-        expect( Hydra::PCDM.collection? works_coll ).to be true
+  describe 'Hydra::PCDM' do
+    describe '#collection?' do
+      it 'returns true for a works collection' do
+        expect(Hydra::PCDM.collection? works_coll).to be true
       end
 
-      it "should return false for a works generic work" do
-        expect( Hydra::PCDM.collection? works_gwork ).to be false
+      it 'returns false for a works generic work' do
+        expect(Hydra::PCDM.collection? works_gwork).to be false
       end
 
-      it "should return false for a works generic file" do
-        expect( Hydra::PCDM.collection? works_gfile ).to be false
+      it 'returns false for a works generic file' do
+        expect(Hydra::PCDM.collection? works_gfile).to be false
       end
 
-      it "should return true for a pcdm collection" do
-        expect( Hydra::PCDM.collection? pcdm_coll ).to be true
+      it 'returns true for a pcdm collection' do
+        expect(Hydra::PCDM.collection? pcdm_coll).to be true
       end
 
-      it "should return false for a pcdm object" do
-        expect( Hydra::PCDM.collection? pcdm_obj ).to be false
+      it 'returns false for a pcdm object' do
+        expect(Hydra::PCDM.collection? pcdm_obj).to be false
       end
 
-      it "should return false for a pcdm file" do
-        expect( Hydra::PCDM.collection? pcdm_file ).to be false
-      end
-    end
-
-    describe "#object?" do
-      it "should return false for a works collection" do
-        expect( Hydra::PCDM.object? works_coll ).to be false
-      end
-
-      it "should return true for a works generic work" do
-        expect( Hydra::PCDM.object? works_gwork ).to be true
-      end
-
-      it "should return true for a works generic file" do
-        expect( Hydra::PCDM.object? works_gfile ).to be true
-      end
-
-      it "should return false for a pcdm collection" do
-        expect( Hydra::PCDM.object? pcdm_coll ).to be false
-      end
-
-      it "should return true for a pcdm object" do
-        expect( Hydra::PCDM.object? pcdm_obj ).to be true
-      end
-
-      it "should return false for a pcdm file" do
-        expect( Hydra::PCDM.object? pcdm_file ).to be false
+      it 'returns false for a pcdm file' do
+        expect(Hydra::PCDM.collection? pcdm_file).to be false
       end
     end
 
+    describe '#object?' do
+      it 'returns false for a works collection' do
+        expect(Hydra::PCDM.object? works_coll).to be false
+      end
+
+      it 'returns true for a works generic work' do
+        expect(Hydra::PCDM.object? works_gwork).to be true
+      end
+
+      it 'returns true for a works generic file' do
+        expect(Hydra::PCDM.object? works_gfile).to be true
+      end
+
+      it 'returns false for a pcdm collection' do
+        expect(Hydra::PCDM.object? pcdm_coll).to be false
+      end
+
+      it 'returns true for a pcdm object' do
+        expect(Hydra::PCDM.object? pcdm_obj).to be true
+      end
+
+      it 'returns false for a pcdm file' do
+        expect(Hydra::PCDM.object? pcdm_file).to be false
+      end
+    end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,12 +35,10 @@ RSpec.configure do |config|
   config.formatter = :progress
 
   config.before :each do |example|
-    unless example.metadata[:no_clean]
-      ActiveFedora::Cleaner.clean!
-    end
+    ActiveFedora::Cleaner.clean! unless example.metadata[:no_clean]
   end
 end
 
 def fixture_path
-  File.expand_path("../fixtures", __FILE__)
+  File.expand_path('../fixtures', __FILE__)
 end


### PR DESCRIPTION
Add mandatory style-checking to the spec task. Clean up the README and badgify per Hydra convention.