### PR TITLE
Remove mapping of file_title and file_author

### DIFF
--- a/lib/hydra/works/models/characterization/document_schema.rb
+++ b/lib/hydra/works/models/characterization/document_schema.rb
@@ -1,6 +1,6 @@
 class DocumentSchema < ActiveTriples::Schema
-  property :title, predicate: RDF::DC11.title
-  property :author, predicate: RDF::DC11.creator
+  property :file_title, predicate: RDF::DC11.title
+  property :file_author, predicate: RDF::DC11.creator
   property :page_count, predicate: RDF::Vocab::NFO.pageCount
   property :file_language, predicate: RDF::DC11.language
   property :word_count, predicate: RDF::Vocab::NFO.wordCount

--- a/lib/hydra/works/models/concerns/file_set/characterization/document.rb
+++ b/lib/hydra/works/models/concerns/file_set/characterization/document.rb
@@ -7,10 +7,6 @@ module Hydra::Works::Characterization
     included do
       # Apply the document schema. This will add properties defined in the schema.
       apply_schema DocumentSchema, AlreadyThereStrategy
-
-      # Update the configuration to map the parsed terms to the correct property.
-      parser_mapping.merge!(file_title: :title,
-                            file_author: :author)
     end
   end
 end

--- a/spec/hydra/works/services/characterization_service_spec.rb
+++ b/spec/hydra/works/services/characterization_service_spec.rb
@@ -17,7 +17,7 @@ describe Hydra::Works::CharacterizationService do
       skip 'external tools not installed for CI environment' if ENV['CI']
       described_class.run(generic_file, path_on_disk)
       expect(generic_file.file_size).to eq(["7618"])
-      expect(generic_file.title).to eq(["sample-file"])
+      expect(generic_file.file_title).to eq(["sample-file"])
       expect(generic_file.page_count).to eq(["1"])
     end
   end
@@ -108,7 +108,7 @@ describe Hydra::Works::CharacterizationService do
       end
 
       it 'assigns expected values to document properties.' do
-        expect(generic_file.title).to eq(["sample-file"])
+        expect(generic_file.file_title).to eq(["sample-file"])
         expect(generic_file.page_count).to eq(["1"])
       end
     end


### PR DESCRIPTION
Fixes #226
Remove custom mapping of file_title and file_author.
This will avoid over writing existing title and author values.