### PR TITLE
Fix Rubocop violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 require: rubocop-rspec
 
 AllCops:
-  RunRailsCops: true
   DisplayCopNames: true
   Include:
     - '**/Rakefile'

--- a/lib/hydra/works/models/characterization/fits_datastream.rb
+++ b/lib/hydra/works/models/characterization/fits_datastream.rb
@@ -100,7 +100,7 @@ module Hydra::Works::Characterization
       t.copyright_note(proxy: [:fileinfo, :copyright_note])
       t.well_formed(proxy: [:filestatus, :well_formed])
       t.valid(proxy: [:filestatus, :valid])
-      t.status_message(proxy: [:filestatus, :status_message])
+      t.filestatus_message(proxy: [:filestatus, :status_message])
       t.file_title(proxy: [:metadata, :document, :file_title])
       t.file_author(proxy: [:metadata, :document, :file_author])
       t.page_count(proxy: [:metadata, :document, :page_count])

--- a/lib/hydra/works/services/add_file_to_file_set.rb
+++ b/lib/hydra/works/services/add_file_to_file_set.rb
@@ -71,13 +71,13 @@ module Hydra::Works
         # @param object for original name to be determined. Attempts to use methods: :original_name, :original_filename, and :path.
         def determine_original_name(file)
           if file.respond_to? :original_name
-            return file.original_name
+            file.original_name
           elsif file.respond_to? :original_filename
-            return file.original_filename
+            file.original_filename
           elsif file.respond_to? :path
-            return ::File.basename(file.path)
+            ::File.basename(file.path)
           else
-            return ''
+            ''
           end
         end
 

--- a/lib/hydra/works/services/characterization_service.rb
+++ b/lib/hydra/works/services/characterization_service.rb
@@ -105,8 +105,8 @@ module Hydra::Works
       def property_for(term)
         if mapping.key?(term) && object.respond_to?(mapping[term])
           mapping[term]
-        else
-          term if object.respond_to?(term)
+        elsif object.respond_to?(term)
+          term
         end
       end
 

--- a/lib/hydra/works/version.rb
+++ b/lib/hydra/works/version.rb
@@ -1,5 +1,5 @@
 module Hydra
   module Works
-    VERSION = '0.6.0'
+    VERSION = '0.6.0'.freeze
   end
 end

--- a/spec/hydra/works_spec.rb
+++ b/spec/hydra/works_spec.rb
@@ -56,53 +56,53 @@ describe Hydra::Works do
   describe 'Hydra::PCDM' do
     describe '#collection?' do
       it 'returns true for a works collection' do
-        expect(Hydra::PCDM.collection? works_coll).to be true
+        expect(Hydra::PCDM.collection?(works_coll)).to be true
       end
 
       it 'returns false for a works generic work' do
-        expect(Hydra::PCDM.collection? works_gwork).to be false
+        expect(Hydra::PCDM.collection?(works_gwork)).to be false
       end
 
       it 'returns false for a works file set' do
-        expect(Hydra::PCDM.collection? file_set).to be false
+        expect(Hydra::PCDM.collection?(file_set)).to be false
       end
 
       it 'returns true for a pcdm collection' do
-        expect(Hydra::PCDM.collection? pcdm_coll).to be true
+        expect(Hydra::PCDM.collection?(pcdm_coll)).to be true
       end
 
       it 'returns false for a pcdm object' do
-        expect(Hydra::PCDM.collection? pcdm_obj).to be false
+        expect(Hydra::PCDM.collection?(pcdm_obj)).to be false
       end
 
       it 'returns false for a pcdm file' do
-        expect(Hydra::PCDM.collection? pcdm_file).to be false
+        expect(Hydra::PCDM.collection?(pcdm_file)).to be false
       end
     end
 
     describe '#object?' do
       it 'returns false for a works collection' do
-        expect(Hydra::PCDM.object? works_coll).to be false
+        expect(Hydra::PCDM.object?(works_coll)).to be false
       end
 
       it 'returns true for a works generic work' do
-        expect(Hydra::PCDM.object? works_gwork).to be true
+        expect(Hydra::PCDM.object?(works_gwork)).to be true
       end
 
       it 'returns true for a works file set' do
-        expect(Hydra::PCDM.object? file_set).to be true
+        expect(Hydra::PCDM.object?(file_set)).to be true
       end
 
       it 'returns false for a pcdm collection' do
-        expect(Hydra::PCDM.object? pcdm_coll).to be false
+        expect(Hydra::PCDM.object?(pcdm_coll)).to be false
       end
 
       it 'returns true for a pcdm object' do
-        expect(Hydra::PCDM.object? pcdm_obj).to be true
+        expect(Hydra::PCDM.object?(pcdm_obj)).to be true
       end
 
       it 'returns false for a pcdm file' do
-        expect(Hydra::PCDM.object? pcdm_file).to be false
+        expect(Hydra::PCDM.object?(pcdm_file)).to be false
       end
     end
   end


### PR DESCRIPTION
Also, rename the `status_message` characterization term to `filestatus_message`, because AF 9.7.1 adds this method to AF::Base objects.