### PR TITLE
Do not declare engine_cart as a dependency, because we do not use engine_cart

### DIFF
--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
-  spec.add_development_dependency 'engine_cart', '~> 0'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'jettywrapper', '>= 2.0.0'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
Because hydra-works does not use Rails. Blocked by #262,