### PR TITLE
Tightening dependency of hydra-pcdm

### DIFF
--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'hydra-pcdm', '>= 0.6'
+  spec.add_dependency 'hydra-pcdm', '~> 0.6'
   spec.add_dependency 'hydra-derivatives', '~> 3.0'
   spec.add_dependency 'hydra-file_characterization', '~> 0.3', '>= 0.3.3'
 


### PR DESCRIPTION
Given that hydra-pcdm is not yet v1.0 (and thus a stable API), I want
to keep the dependency a bit more clamped down. It highlights that
hydra-works and hydra-pcdm are happening in tandem.