### PR TITLE
Refactoring to remove exclusions for rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,30 +12,9 @@ AllCops:
 Metrics/LineLength:
   Enabled: false
 
-Metrics/CyclomaticComplexity:
-  Exclude:
-    - lib/hydra/works/services/add_file_to_file_set.rb
-
-Metrics/PerceivedComplexity:
-  Exclude:
-    - lib/hydra/works/services/add_file_to_file_set.rb
-
-Metrics/MethodLength:
-  Exclude:
-    - lib/hydra/works/services/add_file_to_file_set.rb
-    - lib/hydra/works/models/concerns/file_set/virus_check.rb
-    - lib/hydra/works/models/characterization/fits_datastream.rb
-
 Metrics/ClassLength:
   Exclude:
     - lib/hydra/works/models/characterization/fits_datastream.rb
-
-Metrics/AbcSize:
-  Exclude:
-    - lib/hydra/works/services/add_file_to_file_set.rb
-    - lib/hydra/works/services/full_text_extraction_service.rb
-    - lib/hydra/works/models/concerns/file_set/mime_types.rb
-    - lib/hydra/works/models/concerns/file_set/virus_check.rb
 
 Style/CollectionMethods:
   PreferredMethods:

--- a/lib/hydra/works/models/characterization/fits_datastream.rb
+++ b/lib/hydra/works/models/characterization/fits_datastream.rb
@@ -148,11 +148,9 @@ module Hydra::Works::Characterization
       builder = Nokogiri::XML::Builder.new do |xml|
         xml.fits(xmlns: 'http://hul.harvard.edu/ois/xml/ns/fits/fits_output',
                  'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-                 'xsi:schemaLocation' =>
-      "http://hul.harvard.edu/ois/xml/ns/fits/fits_output
-      http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd",
-                 version: '0.6.0',
-                 timestamp: '1/25/12 11:04 AM') do
+                 'xsi:schemaLocation' => "http://hul.harvard.edu/ois/xml/ns/fits/fits_output
+                 http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd",
+                 version: '0.6.0', timestamp: '1/25/12 11:04 AM') do
           xml.identification { xml.identity(toolname: 'FITS') }
         end
       end

--- a/lib/hydra/works/models/concerns/file_set/virus_check.rb
+++ b/lib/hydra/works/models/concerns/file_set/virus_check.rb
@@ -9,25 +9,27 @@ module Hydra::Works
     # Default behavior is to raise a validation error and halt the save if a virus is found
     def detect_viruses
       return unless original_file && original_file.new_record?
-
       path = original_file.is_a?(String) ? original_file : local_path_for_file(original_file)
       unless defined?(ClamAV)
         warning "Virus checking disabled, #{path} not checked"
         return
       end
-
       scan_result = ClamAV.instance.scanfile(path)
-      if scan_result == 0
-        true
-      else
-        virus_message = "A virus was found in #{path}: #{scan_result}"
-        warning(virus_message)
-        errors.add(:base, virus_message)
-        false
-      end
+      handle_virus_scan_results(path, scan_result)
     end
 
     private
+
+      def handle_virus_scan_results(path, scan_result)
+        if scan_result == 0
+          true
+        else
+          virus_message = "A virus was found in #{path}: #{scan_result}"
+          warning(virus_message)
+          errors.add(:base, virus_message)
+          false
+        end
+      end
 
       def warning(msg)
         ActiveFedora::Base.logger.warn msg if ActiveFedora::Base.logger
@@ -36,16 +38,13 @@ module Hydra::Works
       # Returns a path for reading the content of +file+
       # @param [File] file object to retrieve a path for
       def local_path_for_file(file)
-        if file.respond_to?(:path)
-          file.path
-        else
-          Tempfile.open('') do |t|
-            t.binmode
-            t.write(file.content.read)
-            file.content.rewind
-            t.close
-            t.path
-          end
+        return file.path if file.respond_to?(:path)
+        Tempfile.open('') do |t|
+          t.binmode
+          t.write(file.content.read)
+          file.content.rewind
+          t.close
+          t.path
         end
       end
   end

--- a/lib/hydra/works/services/add_file_to_file_set.rb
+++ b/lib/hydra/works/services/add_file_to_file_set.rb
@@ -80,18 +80,25 @@ module Hydra::Works
         # @param [true, false] update_existing when true, try to retrieve existing element before building one
         def find_or_create_file(type, update_existing)
           if type.instance_of? Symbol
-            association = file_set.association(type)
-            fail ArgumentError, "you're attempting to add a file to a file_set using '#{type}' association but the file_set does not have an association called '#{type}''" unless association
-
-            current_file = association.reader if update_existing
-            current_file || association.build
+            find_or_create_file_for_symbol(type, update_existing)
           else
-            current_file = file_set.filter_files_by_type(type_to_uri(type)).first if update_existing
-            unless current_file
-              file_set.files.build
-              current_file = file_set.files.last
-              Hydra::PCDM::AddTypeToFile.call(current_file, type_to_uri(type))
-            end
+            find_or_create_file_for_rdf_uri(type, update_existing)
+          end
+        end
+
+        def find_or_create_file_for_symbol(type, update_existing)
+          association = file_set.association(type)
+          fail ArgumentError, "you're attempting to add a file to a file_set using '#{type}' association but the file_set does not have an association called '#{type}''" unless association
+          current_file = association.reader if update_existing
+          current_file || association.build
+        end
+
+        def find_or_create_file_for_rdf_uri(type, update_existing)
+          current_file = file_set.filter_files_by_type(type_to_uri(type)).first if update_existing
+          unless current_file
+            file_set.files.build
+            current_file = file_set.files.last
+            Hydra::PCDM::AddTypeToFile.call(current_file, type_to_uri(type))
           end
         end
 


### PR DESCRIPTION
There were a handful of exclusions for some Rubocop scenarios. This bit
of refactoring is a simple extraction of methods to better comply with
Rubocop.