### PR TITLE
Extracting VirusCheckService from module mixin

### DIFF
--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -38,6 +38,7 @@ module Hydra
     end
 
     autoload_under 'services' do
+      autoload :VirusCheckerService
       autoload :AddFileToFileSet
       autoload :UploadFileToFileSet
       autoload :PersistDerivative

--- a/lib/hydra/works/models/concerns/file_set/virus_check.rb
+++ b/lib/hydra/works/models/concerns/file_set/virus_check.rb
@@ -4,48 +4,12 @@ module Hydra::Works
 
     included do
       validate :detect_viruses
+      def detect_viruses
+        return true unless original_file && original_file.new_record? # We have a new file to check
+        return true unless VirusCheckerService.file_has_virus?(original_file)
+        errors.add(:base, "Failed to verify uploaded file is not a virus")
+        false
+      end
     end
-
-    # Default behavior is to raise a validation error and halt the save if a virus is found
-    def detect_viruses
-      return unless original_file && original_file.new_record?
-      path = original_file.is_a?(String) ? original_file : local_path_for_file(original_file)
-      unless defined?(ClamAV)
-        warning "Virus checking disabled, #{path} not checked"
-        return
-      end
-      scan_result = ClamAV.instance.scanfile(path)
-      handle_virus_scan_results(path, scan_result)
-    end
-
-    private
-
-      def handle_virus_scan_results(path, scan_result)
-        if scan_result == 0
-          true
-        else
-          virus_message = "A virus was found in #{path}: #{scan_result}"
-          warning(virus_message)
-          errors.add(:base, virus_message)
-          false
-        end
-      end
-
-      def warning(msg)
-        ActiveFedora::Base.logger.warn msg if ActiveFedora::Base.logger
-      end
-
-      # Returns a path for reading the content of +file+
-      # @param [File] file object to retrieve a path for
-      def local_path_for_file(file)
-        return file.path if file.respond_to?(:path)
-        Tempfile.open('') do |t|
-          t.binmode
-          t.write(file.content.read)
-          file.content.rewind
-          t.close
-          t.path
-        end
-      end
   end
 end

--- a/lib/hydra/works/services/virus_checker_service.rb
+++ b/lib/hydra/works/services/virus_checker_service.rb
@@ -1,0 +1,73 @@
+module Hydra::Works
+  # Responsible for checking if the given file is a virus. Coordinates
+  # with the underlying system virus scanner.
+  class VirusCheckerService
+    attr_accessor :original_file, :system_virus_scanner
+
+    # @api public
+    # @param original_file [String, #path]
+    # @return true if a virus was detected
+    # @return true if anti-virus was not able to run
+    # @return false if the file was scanned and no viruses were found
+    def self.file_has_virus?(original_file)
+      new(original_file).file_has_virus?
+    end
+
+    def initialize(original_file, system_virus_scanner = default_system_virus_scanner)
+      self.original_file = original_file
+      self.system_virus_scanner = system_virus_scanner
+    end
+
+    # Default behavior is to raise a validation error and halt the save if a virus is found
+    def file_has_virus?
+      path = original_file.is_a?(String) ? original_file : local_path_for_file(original_file)
+      scan_result = system_virus_scanner.call(path)
+      handle_virus_scan_results(path, scan_result)
+    end
+
+    private
+
+      # Stubbing out the behavior of "The Clam" was growing into a rather nasty
+      # challenge. So instead I'm injecting a system scanner. This allows me to
+      # now test the default system scanner in isolation from the general response
+      # to a system scan.
+      def default_system_virus_scanner
+        if defined?(ClamAV)
+          ClamAV.instance.method(:scanfile)
+        else
+          lambda do |_path|
+            :no_anti_virus_was_run
+          end
+        end
+      end
+
+      def handle_virus_scan_results(path, scan_result)
+        case scan_result
+        when 0 then return false
+        when 1
+          warning("A virus was found in #{path}: #{scan_result}")
+          true
+        else
+          warning "Virus checking disabled, #{path} not checked"
+          true
+        end
+      end
+
+      def warning(msg)
+        ActiveFedora::Base.logger.warn msg if ActiveFedora::Base.logger
+      end
+
+      # Returns a path for reading the content of +file+
+      # @param [File] file object to retrieve a path for
+      def local_path_for_file(file)
+        return file.path if file.respond_to?(:path)
+        Tempfile.open('') do |t|
+          t.binmode
+          t.write(file.content.read)
+          file.content.rewind
+          t.close
+          t.path
+        end
+      end
+  end
+end

--- a/spec/hydra/works/services/virus_checker_service_spec.rb
+++ b/spec/hydra/works/services/virus_checker_service_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe Hydra::Works::VirusCheckerService do
+  let(:system_virus_scanner) { double(call: nil) }
+  let(:file) { Hydra::PCDM::File.new { |f| f.content = File.new(File.join(fixture_path, 'sample-file.pdf')) } }
+  let(:virus_checker) { described_class.new(file, system_virus_scanner) }
+
+  context '.file_has_virus?' do
+    it 'is a convenience method' do
+      mock_object = double(file_has_virus?: true)
+      allow(described_class).to receive(:new).and_return(mock_object)
+      described_class.file_has_virus?(file)
+      expect(mock_object).to have_received(:file_has_virus?)
+    end
+  end
+
+  context 'with a system virus scanner that did not run' do
+    let(:virus_checker) { described_class.new(file) }
+    it 'will return false and set a system warning' do
+      expect(defined?(ClamAV)).to eq(nil) # A bit of a sanity test to make sure the default behaves
+      allow(file).to receive(:path).and_return('/tmp/file.pdf')
+      expect(virus_checker).to receive(:warning).with(kind_of(String))
+      expect(virus_checker.file_has_virus?).to eq(true)
+    end
+  end
+
+  context 'with an infected file' do
+    context 'that responds to :path' do
+      it 'will return false' do
+        expect(system_virus_scanner).to receive(:call).with('/tmp/file.pdf').and_return(1)
+        allow(file).to receive(:path).and_return('/tmp/file.pdf')
+        expect(virus_checker.file_has_virus?).to eq(true)
+      end
+    end
+    context 'that does not respond to :path' do
+      it 'will return false' do
+        expect(system_virus_scanner).to receive(:call).with(kind_of(String)).and_return(1)
+        allow(file).to receive(:respond_to?).and_call_original
+        allow(file).to receive(:respond_to?).with(:path).and_return(false)
+        expect(virus_checker.file_has_virus?).to eq(true)
+      end
+    end
+  end
+
+  context 'with a clean file' do
+    context 'that responds to :path' do
+      it 'will return true' do
+        expect(system_virus_scanner).to receive(:call).with('/tmp/file.pdf').and_return(0)
+        allow(file).to receive(:path).and_return('/tmp/file.pdf')
+        expect(virus_checker.file_has_virus?).to eq(false)
+      end
+    end
+    context 'that does not respond to :path' do
+      it 'will return true' do
+        expect(system_virus_scanner).to receive(:call).with(kind_of(String)).and_return(0)
+        allow(file).to receive(:respond_to?).and_call_original
+        allow(file).to receive(:respond_to?).with(:path).and_return(false)
+        expect(virus_checker.file_has_virus?).to eq(false)
+      end
+    end
+  end
+
+  context '#default_system_virus_scanner' do
+    let(:virus_checker) { described_class.new(file) }
+    let(:system_virus_scanner) { virus_checker.send(:default_system_virus_scanner) }
+    it 'is callable' do
+      expect(system_virus_scanner).to respond_to(:call)
+    end
+    context 'when called and ClamAV is NOT defined' do
+      it 'will warn and return :no_anti_virus_was_run if ClamAV is not defined' do
+        expect(system_virus_scanner.call('/tmp/path')).to eq(:no_anti_virus_was_run)
+      end
+    end
+    context 'when called and ClamAV is defined' do
+      before do
+        class ClamAV
+          def self.instance
+            @instance ||= ClamAV.new
+          end
+
+          def scanfile(path)
+            puts "scanfile: #{path}"
+          end
+        end
+      end
+      after do
+        Object.send(:remove_const, :ClamAV)
+      end
+      it "will call the Clam's scanfile" do
+        expect(ClamAV.instance).to receive(:scanfile).with('/tmp/path')
+        system_virus_scanner.call('/tmp/path')
+      end
+    end
+  end
+end


### PR DESCRIPTION
One of the major disadvantages of module mixins is that several methods
often get defined on the object. This greatly increases the chance of
method collisions if lots of mixins are used.

So, while preserving much of the outward interface of the
`Hydra::Works::VirusCheck`'s validation, I'm extracting a collaborating
class that can do the heavy lifting against the file.

This involved a bit of additional refactoring as I was encountering
challenges with ClamAV definitions. By relying also on dependency
injection of the system virus scanner, I can more easily test each
piece of the anti-virus process in better isolation.