### PR TITLE
Use our own VirusScanner, fixes #296

### DIFF
--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -6,6 +6,13 @@ module Hydra
   module Works
     extend ActiveSupport::Autoload
 
+    autoload :VirusScanner
+
+    class << self
+      class_attribute :default_system_virus_scanner
+      self.default_system_virus_scanner = VirusScanner
+    end
+
     module Vocab
       extend ActiveSupport::Autoload
       eager_autoload do

--- a/lib/hydra/works/services/virus_checker_service.rb
+++ b/lib/hydra/works/services/virus_checker_service.rb
@@ -6,14 +6,12 @@ module Hydra::Works
 
     # @api public
     # @param original_file [String, #path]
-    # @return true if a virus was detected
-    # @return true if anti-virus was not able to run
-    # @return false if the file was scanned and no viruses were found
+    # @return true or false result from system_virus_scanner
     def self.file_has_virus?(original_file)
       new(original_file).file_has_virus?
     end
 
-    def initialize(original_file, system_virus_scanner = default_system_virus_scanner)
+    def initialize(original_file, system_virus_scanner = Hydra::Works.default_system_virus_scanner)
       self.original_file = original_file
       self.system_virus_scanner = system_virus_scanner
     end
@@ -21,41 +19,10 @@ module Hydra::Works
     # Default behavior is to raise a validation error and halt the save if a virus is found
     def file_has_virus?
       path = original_file.is_a?(String) ? original_file : local_path_for_file(original_file)
-      scan_result = system_virus_scanner.call(path)
-      handle_virus_scan_results(path, scan_result)
+      system_virus_scanner.infected?(path)
     end
 
     private
-
-      # Stubbing out the behavior of "The Clam" was growing into a rather nasty
-      # challenge. So instead I'm injecting a system scanner. This allows me to
-      # now test the default system scanner in isolation from the general response
-      # to a system scan.
-      def default_system_virus_scanner
-        if defined?(ClamAV)
-          ClamAV.instance.method(:scanfile)
-        else
-          lambda do |_path|
-            :no_anti_virus_was_run
-          end
-        end
-      end
-
-      def handle_virus_scan_results(path, scan_result)
-        case scan_result
-        when 0 then return false
-        when 1
-          warning("A virus was found in #{path}: #{scan_result}")
-          true
-        else
-          warning "Virus checking disabled, #{path} not checked"
-          true
-        end
-      end
-
-      def warning(msg)
-        ActiveFedora::Base.logger.warn msg if ActiveFedora::Base.logger
-      end
 
       # Returns a path for reading the content of +file+
       # @param [File] file object to retrieve a path for

--- a/lib/hydra/works/virus_scanner.rb
+++ b/lib/hydra/works/virus_scanner.rb
@@ -1,0 +1,56 @@
+# The default virus scanner for Hydra::Works
+# If ClamAV is present, it will be used to check for the presence of a virus. If ClamAV is not
+# installed or otherwise not available to your application, Hydra::Works does no virus checking
+# add assumes files have no viruses.
+#
+# To use a virus checker other than ClamAV:
+#   class MyScanner < Hydra::Works::VirusScanner
+#     def infected?
+#       my_result = Scanner.check_for_viruses(file)
+#       [return true or false]
+#     end
+#   end
+#
+# Then set Hydra::Works to use your scanner either in a config file or initializer:
+#   Hydra::Works.default_system_virus_scanner = MyScanner
+module Hydra::Works
+  class VirusScanner
+    attr_reader :file
+
+    # @api public
+    # @param file [String]
+    def self.infected?(file)
+      new(file).infected?
+    end
+
+    def initialize(file)
+      @file = file
+    end
+
+    # Override this method to use your own virus checking software
+    # @return [Boolean]
+    def infected?
+      defined?(ClamAV) ? clam_av_scanner : null_scanner
+    end
+
+    def clam_av_scanner
+      scan_result = ClamAV.instance.method(:scanfile).call(file)
+      return false if scan_result == 0
+      warning "A virus was found in #{file}: #{scan_result}"
+      true
+    end
+
+    # Always return zero if there's nothing available to check for viruses. This means that
+    # we assume all files have no viruses because we can't conclusively say if they have or not.
+    def null_scanner
+      warning "Unable to check #{file} for viruses because no virus scanner is defined"
+      false
+    end
+
+    private
+
+      def warning(msg)
+        ActiveFedora::Base.logger.warn(msg) if ActiveFedora::Base.logger
+      end
+  end
+end

--- a/spec/hydra/works/services/virus_checker_service_spec.rb
+++ b/spec/hydra/works/services/virus_checker_service_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Hydra::Works::VirusCheckerService do
-  let(:system_virus_scanner) { double(call: nil) }
+  let(:system_virus_scanner) { double }
   let(:file) { Hydra::PCDM::File.new { |f| f.content = File.new(File.join(fixture_path, 'sample-file.pdf')) } }
   let(:virus_checker) { described_class.new(file, system_virus_scanner) }
 
@@ -14,27 +14,17 @@ describe Hydra::Works::VirusCheckerService do
     end
   end
 
-  context 'with a system virus scanner that did not run' do
-    let(:virus_checker) { described_class.new(file) }
-    it 'will return false and set a system warning' do
-      expect(defined?(ClamAV)).to eq(nil) # A bit of a sanity test to make sure the default behaves
-      allow(file).to receive(:path).and_return('/tmp/file.pdf')
-      expect(virus_checker).to receive(:warning).with(kind_of(String))
-      expect(virus_checker.file_has_virus?).to eq(true)
-    end
-  end
-
   context 'with an infected file' do
     context 'that responds to :path' do
       it 'will return false' do
-        expect(system_virus_scanner).to receive(:call).with('/tmp/file.pdf').and_return(1)
+        expect(system_virus_scanner).to receive(:infected?).with('/tmp/file.pdf').and_return(true)
         allow(file).to receive(:path).and_return('/tmp/file.pdf')
         expect(virus_checker.file_has_virus?).to eq(true)
       end
     end
     context 'that does not respond to :path' do
       it 'will return false' do
-        expect(system_virus_scanner).to receive(:call).with(kind_of(String)).and_return(1)
+        expect(system_virus_scanner).to receive(:infected?).with(kind_of(String)).and_return(true)
         allow(file).to receive(:respond_to?).and_call_original
         allow(file).to receive(:respond_to?).with(:path).and_return(false)
         expect(virus_checker.file_has_virus?).to eq(true)
@@ -45,50 +35,17 @@ describe Hydra::Works::VirusCheckerService do
   context 'with a clean file' do
     context 'that responds to :path' do
       it 'will return true' do
-        expect(system_virus_scanner).to receive(:call).with('/tmp/file.pdf').and_return(0)
+        expect(system_virus_scanner).to receive(:infected?).with('/tmp/file.pdf').and_return(false)
         allow(file).to receive(:path).and_return('/tmp/file.pdf')
         expect(virus_checker.file_has_virus?).to eq(false)
       end
     end
     context 'that does not respond to :path' do
       it 'will return true' do
-        expect(system_virus_scanner).to receive(:call).with(kind_of(String)).and_return(0)
+        expect(system_virus_scanner).to receive(:infected?).with(kind_of(String)).and_return(false)
         allow(file).to receive(:respond_to?).and_call_original
         allow(file).to receive(:respond_to?).with(:path).and_return(false)
         expect(virus_checker.file_has_virus?).to eq(false)
-      end
-    end
-  end
-
-  context '#default_system_virus_scanner' do
-    let(:virus_checker) { described_class.new(file) }
-    let(:system_virus_scanner) { virus_checker.send(:default_system_virus_scanner) }
-    it 'is callable' do
-      expect(system_virus_scanner).to respond_to(:call)
-    end
-    context 'when called and ClamAV is NOT defined' do
-      it 'will warn and return :no_anti_virus_was_run if ClamAV is not defined' do
-        expect(system_virus_scanner.call('/tmp/path')).to eq(:no_anti_virus_was_run)
-      end
-    end
-    context 'when called and ClamAV is defined' do
-      before do
-        class ClamAV
-          def self.instance
-            @instance ||= ClamAV.new
-          end
-
-          def scanfile(path)
-            puts "scanfile: #{path}"
-          end
-        end
-      end
-      after do
-        Object.send(:remove_const, :ClamAV)
-      end
-      it "will call the Clam's scanfile" do
-        expect(ClamAV.instance).to receive(:scanfile).with('/tmp/path')
-        system_virus_scanner.call('/tmp/path')
       end
     end
   end

--- a/spec/hydra/works/virus_scanner_spec.rb
+++ b/spec/hydra/works/virus_scanner_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Hydra::Works::VirusScanner do
+  let(:file)   { '/tmp/path' }
+  let(:logger) { Logger.new(nil) }
+
+  before { allow(ActiveFedora::Base).to receive(:logger).and_return(logger) }
+
+  subject { described_class.new(file) }
+
+  context 'when ClamAV is defined' do
+    before do
+      class ClamAV
+        def self.instance
+          @instance ||= ClamAV.new
+        end
+
+        def scanfile(path)
+          puts "scanfile: #{path}"
+        end
+      end
+    end
+    after do
+      Object.send(:remove_const, :ClamAV)
+    end
+    context 'with a clean file' do
+      before { allow(ClamAV.instance).to receive(:scanfile).with('/tmp/path').and_return(0) }
+      it 'returns false with no warning' do
+        expect(ActiveFedora::Base.logger).not_to receive(:warn)
+        is_expected.not_to be_infected
+      end
+    end
+    context 'with an infected file' do
+      before { allow(ClamAV.instance).to receive(:scanfile).with('/tmp/path').and_return(1) }
+      it 'returns true with a warning' do
+        expect(ActiveFedora::Base.logger).to receive(:warn).with(kind_of(String))
+        is_expected.to be_infected
+      end
+    end
+  end
+
+  context 'when ClamAV is not defined' do
+    it 'returns false with a warning' do
+      expect(ActiveFedora::Base.logger).to receive(:warn).with(kind_of(String))
+      is_expected.not_to be_infected
+    end
+  end
+end

--- a/spec/hydra/works_spec.rb
+++ b/spec/hydra/works_spec.rb
@@ -106,4 +106,9 @@ describe Hydra::Works do
       end
     end
   end
+
+  describe '::default_system_virus_scanner' do
+    subject { described_class.default_system_virus_scanner }
+    it { is_expected.to eq(Hydra::Works::VirusScanner) }
+  end
 end


### PR DESCRIPTION
Creates a settable virus scanner class that defaults to ClamAV, if it is present, or sets a null scanner that reports files have no viruses.